### PR TITLE
Update Fedora installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ If you're using linux, you can check out the "releases" of this repository to do
 
 ### Fedora/CentOS
 
-Available in [COPR](https://copr.fedorainfracloud.org/coprs/atim/diskonaut/):
+```
+sudo dnf install diskonaut
+```
+For older Fedora releases and CentOS available in [COPR](https://copr.fedorainfracloud.org/coprs/atim/diskonaut/):
 ```
 sudo dnf copr enable atim/diskonaut -y
 sudo dnf install diskonaut


### PR DESCRIPTION
Now package available in [main repo](https://src.fedoraproject.org/rpms/rust-diskonaut/) for F32+. Please hold a little bit this PR until we push update for F32.