### PR TITLE
Emacs keys

### DIFF
--- a/src/input/controls.rs
+++ b/src/input/controls.rs
@@ -20,27 +20,39 @@ impl Iterator for KeyboardEvents {
     }
 }
 
+macro_rules! key {
+    (char $c:expr) => {
+        Event::Key(Key::Char($c))
+    };
+    ($x:ident) => {
+        Event::Key(Key::$x)
+    };
+    (ctrl $c:expr) => {
+        Event::Key(Key::Ctrl($c))
+    };
+}
+
 pub fn handle_keypress_loading_mode<B: Backend>(evt: Event, app: &mut App<B>) {
     match evt {
-        Event::Key(Key::Ctrl('c')) | Event::Key(Key::Char('q')) => {
+        key!(ctrl 'c') | key!(char 'q') => {
             app.exit();
         }
-        Event::Key(Key::Char('l')) | Event::Key(Key::Right) | Event::Key(Key::Ctrl('f')) => {
+        key!(char 'l') | key!(Right) | key!(ctrl 'f') => {
             app.move_selected_right();
         }
-        Event::Key(Key::Char('h')) | Event::Key(Key::Left) | Event::Key(Key::Ctrl('b')) => {
+        key!(char 'h') | key!(Left) | key!(ctrl 'b') => {
             app.move_selected_left();
         }
-        Event::Key(Key::Char('j')) | Event::Key(Key::Down) | Event::Key(Key::Ctrl('n')) => {
+        key!(char 'j') | key!(Down) | key!(ctrl 'n') => {
             app.move_selected_down();
         }
-        Event::Key(Key::Char('k')) | Event::Key(Key::Up) | Event::Key(Key::Ctrl('p')) => {
+        key!(char 'k') | key!(Up) | key!(ctrl 'p') => {
             app.move_selected_up();
         }
-        Event::Key(Key::Char('\n')) => {
+        key!(char '\n') => {
             app.enter_selected();
         }
-        Event::Key(Key::Esc) | Event::Key(Key::Backspace) => {
+        key!(Esc) | key!(Backspace) => {
             app.go_up();
         }
         _ => (),
@@ -49,28 +61,28 @@ pub fn handle_keypress_loading_mode<B: Backend>(evt: Event, app: &mut App<B>) {
 
 pub fn handle_keypress_normal_mode<B: Backend>(evt: Event, app: &mut App<B>) {
     match evt {
-        Event::Key(Key::Ctrl('c')) | Event::Key(Key::Char('q')) => {
+        key!(ctrl 'c') | key!(char 'q') => {
             app.exit();
         }
-        Event::Key(Key::Ctrl('d')) => {
+        key!(ctrl 'd') => {
             app.prompt_file_deletion();
         }
-        Event::Key(Key::Char('l')) | Event::Key(Key::Right) => {
+        key!(char 'l') | key!(Right) | key!(ctrl 'f') => {
             app.move_selected_right();
         }
-        Event::Key(Key::Char('h')) | Event::Key(Key::Left) => {
+        key!(char 'h') | key!(Left) | key!(ctrl 'b') => {
             app.move_selected_left();
         }
-        Event::Key(Key::Char('j')) | Event::Key(Key::Down) => {
+        key!(char 'j') | key!(Down) | key!(ctrl 'n') => {
             app.move_selected_down();
         }
-        Event::Key(Key::Char('k')) | Event::Key(Key::Up) => {
+        key!(char 'k') | key!(Up) | key!(ctrl 'p') => {
             app.move_selected_up();
         }
-        Event::Key(Key::Char('\n')) => {
+        key!(char '\n') => {
             app.enter_selected();
         }
-        Event::Key(Key::Esc) | Event::Key(Key::Backspace) => {
+        key!(Esc) | key!(Backspace) => {
             app.go_up();
         }
         _ => (),
@@ -83,14 +95,10 @@ pub fn handle_keypress_delete_file_mode<B: Backend>(
     file_to_delete: FileToDelete,
 ) {
     match evt {
-        Event::Key(Key::Ctrl('c'))
-        | Event::Key(Key::Char('q'))
-        | Event::Key(Key::Esc)
-        | Event::Key(Key::Backspace)
-        | Event::Key(Key::Char('n')) => {
+        key!(ctrl 'c') | key!(char 'q') | key!(Esc) | key!(Backspace) | key!(char '\n') => {
             app.normal_mode();
         }
-        Event::Key(Key::Char('y')) => {
+        key!(char 'y') => {
             app.delete_file(&file_to_delete);
         }
         _ => (),
@@ -99,10 +107,7 @@ pub fn handle_keypress_delete_file_mode<B: Backend>(
 
 pub fn handle_keypress_error_message<B: Backend>(evt: Event, app: &mut App<B>) {
     match evt {
-        Event::Key(Key::Ctrl('c'))
-        | Event::Key(Key::Char('q'))
-        | Event::Key(Key::Esc)
-        | Event::Key(Key::Backspace) => {
+        key!(ctrl 'c') | key!(char 'q') | key!(Esc) | key!(Backspace) => {
             app.normal_mode();
         }
         _ => (),
@@ -111,7 +116,7 @@ pub fn handle_keypress_error_message<B: Backend>(evt: Event, app: &mut App<B>) {
 
 pub fn handle_keypress_screen_too_small<B: Backend>(evt: Event, app: &mut App<B>) {
     match evt {
-        Event::Key(Key::Ctrl('c')) | Event::Key(Key::Char('q')) => {
+        key!(ctrl 'c') | key!(char 'q') => {
             app.exit();
         }
         _ => (),

--- a/src/input/controls.rs
+++ b/src/input/controls.rs
@@ -25,16 +25,16 @@ pub fn handle_keypress_loading_mode<B: Backend>(evt: Event, app: &mut App<B>) {
         Event::Key(Key::Ctrl('c')) | Event::Key(Key::Char('q')) => {
             app.exit();
         }
-        Event::Key(Key::Char('l')) | Event::Key(Key::Right) => {
+        Event::Key(Key::Char('l')) | Event::Key(Key::Right) | Event::Key(Key::Ctrl('f')) => {
             app.move_selected_right();
         }
-        Event::Key(Key::Char('h')) | Event::Key(Key::Left) => {
+        Event::Key(Key::Char('h')) | Event::Key(Key::Left) | Event::Key(Key::Ctrl('b')) => {
             app.move_selected_left();
         }
-        Event::Key(Key::Char('j')) | Event::Key(Key::Down) => {
+        Event::Key(Key::Char('j')) | Event::Key(Key::Down) | Event::Key(Key::Ctrl('n')) => {
             app.move_selected_down();
         }
-        Event::Key(Key::Char('k')) | Event::Key(Key::Up) => {
+        Event::Key(Key::Char('k')) | Event::Key(Key::Up) | Event::Key(Key::Ctrl('p')) => {
             app.move_selected_up();
         }
         Event::Key(Key::Char('\n')) => {


### PR DESCRIPTION
Fixes #36 
I also made a `keys!` macro, which replaces verbose ways of creating `Event::Key(Key::Ctrl('x'))` (or similar) instances. I noticed that this pattern could also be used in the UI testing module and a little bit in `main.rs`, but I didn't change those files.

Also, in the first commit, I forgot to change both instances of where the arrow keys can be used, but that is fixed in the second commit with macros.