### PR TITLE
Prevent crashes on files with multibyte characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tui 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ jwalk = "0.5"
 signal-hook = "0.1.10"
 structopt = "0.3"
 filesize = "0.2.0"
+unicode-width = "0.1.7"
 
 [dev-dependencies]
 insta = "0.16.0"

--- a/src/ui/format/truncate.rs
+++ b/src/ui/format/truncate.rs
@@ -1,11 +1,32 @@
+use std::iter::FromIterator;
+use unicode_width::UnicodeWidthChar;
+
+fn truncate_iter_to_unicode_width<Input, Collect>(iter: Input, width: usize) -> Collect
+where
+    Input: Iterator<Item = char>,
+    Collect: FromIterator<char>,
+{
+    let mut chunk_width = 0;
+    iter
+        .take_while(|ch| {
+            chunk_width += ch.width().unwrap_or(0);
+            chunk_width <= width
+        })
+        .collect()
+}
+
 pub fn truncate_middle(row: &str, max_length: u16) -> String {
     if max_length < 6 {
-        let mut res = String::from(row);
-        res.truncate(max_length as usize);
-        res
+        truncate_iter_to_unicode_width(row.chars(), max_length as usize)
     } else if row.len() as u16 > max_length {
-        let first_slice = &row[0..(max_length as usize / 2) - 2];
-        let second_slice = &row[(row.len() - (max_length / 2) as usize + 2)..row.len()];
+        let split_point = (max_length as usize / 2) - 2;
+        let first_slice = truncate_iter_to_unicode_width::<_, String>(row.chars(), split_point);
+        let second_slice =
+            truncate_iter_to_unicode_width::<_, Vec<_>>(row.chars().rev(), split_point)
+                .into_iter()
+                .rev()
+                .collect::<String>();
+
         if max_length % 2 == 0 {
             format!("{}[...]{}", first_slice, second_slice)
         } else {
@@ -23,5 +44,18 @@ pub fn truncate_end(row: &str, max_len: u16) -> String {
         format!("{}...", truncated)
     } else {
         row.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_middle_char_boundary() {
+        assert_eq!(
+            truncate_middle("굿걸 - 누가 방송국을 털었나 E06.mp4", 44),
+            "굿걸 - 누가 방송국을[...]국을 털었나 E06.mp4",
+        );
     }
 }

--- a/src/ui/format/truncate.rs
+++ b/src/ui/format/truncate.rs
@@ -1,5 +1,5 @@
-use std::iter::FromIterator;
-use unicode_width::UnicodeWidthChar;
+use ::std::iter::FromIterator;
+use ::unicode_width::UnicodeWidthChar;
 
 fn truncate_iter_to_unicode_width<Input, Collect>(iter: Input, width: usize) -> Collect
 where
@@ -7,12 +7,11 @@ where
     Collect: FromIterator<char>,
 {
     let mut chunk_width = 0;
-    iter
-        .take_while(|ch| {
-            chunk_width += ch.width().unwrap_or(0);
-            chunk_width <= width
-        })
-        .collect()
+    iter.take_while(|ch| {
+        chunk_width += ch.width().unwrap_or(0);
+        chunk_width <= width
+    })
+    .collect()
 }
 
 pub fn truncate_middle(row: &str, max_length: u16) -> String {

--- a/src/ui/grid/draw_rect.rs
+++ b/src/ui/grid/draw_rect.rs
@@ -1,6 +1,7 @@
 use ::tui::buffer::Buffer;
 use ::tui::layout::Rect;
 use ::tui::style::{Color, Modifier, Style};
+use ::unicode_width::UnicodeWidthStr;
 
 use crate::state::tiles::{FileType, Tile};
 use crate::ui::format::{truncate_middle, DisplaySize, DisplaySizeRounded};
@@ -167,11 +168,11 @@ pub fn draw_filled_rect(buf: &mut Buffer, fill_style: Style, rect: &Rect) {
 
 pub fn draw_tile_text_on_grid(buf: &mut Buffer, tile: &Tile, selected: bool) {
     let first_line = tile_first_line(&tile);
-    let first_line_length = first_line.chars().count() as u16;
+    let first_line_length = first_line.width() as u16;
     let first_line_start_position =
         ((tile.width - first_line_length) as f64 / 2.0).ceil() as u16 + tile.x;
     let second_line = tile_second_line(&tile);
-    let second_line_length = second_line.chars().count();
+    let second_line_length = second_line.width();
     let second_line_start_position =
         ((tile.width - second_line_length as u16) as f64 / 2.0).ceil() as u16 + tile.x;
     let (background_style, first_line_style, second_line_style) = tile_style(&tile, selected);


### PR DESCRIPTION
Hi! When I ran `diskonaut`, I got an error like this on some of my folders:
```
thread 'main' panicked at 'byte index 27 is not a char boundary; it is inside '을' (bytes 25..28) of `굿걸 - 누가 방송국을 털었나 E06.mp4`'
```
This is because `truncate_middle` was trying to slice inside the middle of a multibyte unicode character.

My first naive attempt was to slice based on character counts using `.chars().take(N)`. That fixes the crash but reveals a different issue:
![image](https://user-images.githubusercontent.com/1006268/85790998-70aeb600-b731-11ea-9e25-1cb203a55309.png)


CJK characters in particular are often wider than latin characters, and the `max_length` value is in bytes so if there are multibyte characters it shows too many on either side of the `[..]`.

I ended up using the `unicode-width` crate, which will tell you how wide a character is supposed to be. It isn't perfect when emoji combinations with ZWJ characters are in play, but it seems to work well for words and letters:
![image](https://user-images.githubusercontent.com/1006268/85789418-d8173680-b72e-11ea-8789-bd80dab12e70.png)


I just added a simple unit test for this but it looks like all the existing tests are actually a bit more advanced. If you'd prefer that this is also tested through the `tests::cases::ui` module I can do that but probably not now because I don't have time :innocent:

Thanks!