### PR TITLE
fix(rendering): prevent corrupted small files rendering

### DIFF
--- a/src/state/tiles/treemap.rs
+++ b/src/state/tiles/treemap.rs
@@ -99,6 +99,10 @@ impl TreeMap {
         }
     }
     fn add_unrenderable_tile(&mut self, tile: &Tile) {
+        if tile.width == 0 || tile.height == 0 {
+            // this is a rounding error, do not add it
+            return;
+        }
         match self.unrenderable_tile_coordinates {
             Some((x, y)) => {
                 let x = if tile.x < x { tile.x } else { x };


### PR DESCRIPTION
This fixes some edge cases in which adding a tile with 0 width or 0 height would mess up the small files area rendering. (render it on top of other rectangles).