### PR TITLE
fix: Use u128 for sizes (#52)

### DIFF
--- a/src/state/file_to_delete.rs
+++ b/src/state/file_to_delete.rs
@@ -9,7 +9,7 @@ pub struct FileToDelete {
     pub path_to_file: Vec<OsString>,
     pub file_type: FileType,
     pub num_descendants: Option<u64>,
-    pub size: u64,
+    pub size: u128,
 }
 
 impl FileToDelete {

--- a/src/state/files/file_or_folder.rs
+++ b/src/state/files/file_or_folder.rs
@@ -12,7 +12,7 @@ pub enum FileOrFolder {
 }
 
 impl FileOrFolder {
-    pub fn size(&self) -> u64 {
+    pub fn size(&self) -> u128 {
         match self {
             FileOrFolder::Folder(folder) => folder.size,
             FileOrFolder::File(file) => file.size,
@@ -23,14 +23,14 @@ impl FileOrFolder {
 #[derive(Debug, Clone)]
 pub struct File {
     pub name: OsString,
-    pub size: u64,
+    pub size: u128,
 }
 
 #[derive(Debug, Clone)]
 pub struct Folder {
     pub name: OsString,
     pub contents: HashMap<OsString, FileOrFolder>,
-    pub size: u64,
+    pub size: u128,
     pub num_descendants: u64,
 }
 
@@ -61,7 +61,7 @@ impl Folder {
         } else {
             let size = relative_path
                 .size_on_disk_fast(&entry_metadata)
-                .unwrap_or(entry_metadata.len());
+                .unwrap_or(entry_metadata.len()) as u128;
             self.add_file(relative_path, size);
         }
     }
@@ -97,7 +97,7 @@ impl Folder {
                 .insert(name.clone(), FileOrFolder::Folder(Folder::from(name)));
         }
     }
-    pub fn add_file(&mut self, path: PathBuf, size: u64) {
+    pub fn add_file(&mut self, path: PathBuf, size: u128) {
         let path_length = path.components().count();
         if path_length == 0 {
             return;

--- a/src/state/files/file_tree.rs
+++ b/src/state/files/file_tree.rs
@@ -8,7 +8,7 @@ use crate::state::FileToDelete;
 pub struct FileTree {
     base_folder: Folder,
     pub current_folder_names: Vec<OsString>,
-    pub space_freed: u64,
+    pub space_freed: u128,
     pub failed_to_read: u64,
     pub path_in_filesystem: PathBuf,
 }
@@ -23,7 +23,7 @@ impl FileTree {
             failed_to_read: 0,
         }
     }
-    pub fn get_total_size(&self) -> u64 {
+    pub fn get_total_size(&self) -> u128 {
         self.base_folder.size
     }
     pub fn get_total_descendants(&self) -> u64 {
@@ -42,7 +42,7 @@ impl FileTree {
             unreachable!("couldn't find current folder size")
         }
     }
-    pub fn get_current_folder_size(&self) -> u64 {
+    pub fn get_current_folder_size(&self) -> u128 {
         self.get_current_folder().size
     }
     pub fn get_current_path(&self) -> PathBuf {

--- a/src/state/tiles/files_in_folder.rs
+++ b/src/state/tiles/files_in_folder.rs
@@ -11,13 +11,13 @@ pub enum FileType {
 #[derive(Debug, Clone)]
 pub struct FileMetadata {
     pub name: OsString,
-    pub size: u64,
+    pub size: u128,
     pub descendants: Option<u64>,
     pub percentage: f64, // 1.0 is 100% (0.5 is 50%, etc.)
     pub file_type: FileType,
 }
 
-fn calculate_percentage(size: u64, total_size: u64, total_files_in_parent: usize) -> f64 {
+fn calculate_percentage(size: u128, total_size: u128, total_files_in_parent: usize) -> f64 {
     if size == 0 && total_size == 0 {
         // if all files in the folder are of size 0, we'll want to display them all as
         // the same size

--- a/src/state/tiles/tile.rs
+++ b/src/state/tiles/tile.rs
@@ -9,7 +9,7 @@ pub struct Tile {
     pub width: u16,
     pub height: u16,
     pub name: OsString,
-    pub size: u64,
+    pub size: u128,
     pub descendants: Option<u64>,
     pub percentage: f64,
     pub file_type: FileType,

--- a/src/ui/display.rs
+++ b/src/ui/display.rs
@@ -14,7 +14,7 @@ use crate::UiMode;
 
 pub struct FolderInfo<'a> {
     pub path: &'a PathBuf,
-    pub size: u64,
+    pub size: u128,
     pub num_descendants: u64,
 }
 

--- a/src/ui/title/title_line.rs
+++ b/src/ui/title/title_line.rs
@@ -13,7 +13,7 @@ use nix::unistd::geteuid;
 pub struct TitleLine<'a> {
     base_path_info: FolderInfo<'a>,
     current_path_info: FolderInfo<'a>,
-    space_freed: u64,
+    space_freed: u128,
     show_loading: bool,
     progress_indicator: u64,
     read_errors: Option<u64>,
@@ -26,7 +26,7 @@ impl<'a> TitleLine<'a> {
     pub fn new(
         base_path_info: FolderInfo<'a>,
         current_path_info: FolderInfo<'a>,
-        space_freed: u64,
+        space_freed: u128,
     ) -> Self {
         Self {
             base_path_info,


### PR DESCRIPTION
With this I successfully sized an 8 zettabyte folder (after hacking in use of `len()` rather than `size_on_disk()`).