### PR TITLE
docs(readme): add nix installation info

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ Available through the following overlay as `sys-fs/diskonaut`:
 
 https://github.com/telans/EBUILDS
 
+### Nix / NixOS
+Available in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/misc/diskonaut/default.nix):
+```
+$ nix-env --install diskonaut
+$ # (Or using the attribute name, which is also diskonaut.)
+```
+
 ## Supported platforms
 Right now `diskonaut` supports linux and macos. If you're on a different operating system and would like to help port it, that would be amazing!
 


### PR DESCRIPTION
diskonaut was added to nixpkgs in https://github.com/NixOS/nixpkgs/commit/2dad77e05c5e2b690d3efdae3b73d0c3c9c84e60 via https://github.com/NixOS/nixpkgs/pull/91460.

This is available now for the `nixos-unstable` and `nixpkgs-unstable` channels, and will be included as a part of the `nixos-20.09` release.