### PR TITLE
Add installation instructions with NIX on OX

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Available in [Homebrew](https://formulae.brew.sh/formula/diskonaut)
 ```
 brew install diskonaut
 ```
+Available in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/misc/diskonaut/default.nix):
+```
+$ nix-env --install diskonaut
+```
 
 ## Supported platforms
 Right now `diskonaut` supports linux and macos. If you're on a different operating system and would like to help port it, that would be amazing!


### PR DESCRIPTION
We can install diskonaut on OSX using NIX too.