### PR TITLE
Add GitHub Actions (GHA) CICD workflow

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -274,18 +274,18 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          # { os, target, cargo-options, features, use-cross, toolchain }
+          # { os, target, cargo-options, features, use-cross, toolchain, withhold }
           ## - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , use-cross: use-cross }
           ## - { os: ubuntu-latest  , target: aarch64-unknown-linux-gnu   , use-cross: use-cross }
           - { os: ubuntu-latest  , target: i686-unknown-linux-gnu      , use-cross: use-cross }
-          - { os: ubuntu-latest  , target: i686-unknown-linux-musl     , use-cross: use-cross }
-          - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , use-cross: use-cross }
-          - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , use-cross: use-cross }
+          - { os: ubuntu-latest  , target: i686-unknown-linux-musl     , use-cross: use-cross , withhold: withhold }
+          - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , use-cross: use-cross , withhold: withhold }
+          - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , use-cross: use-cross , withhold: withhold }
           - { os: macos-latest   , target: x86_64-apple-darwin         }
-          - { os: windows-latest , target: i686-pc-windows-gnu         }
+          - { os: windows-latest , target: i686-pc-windows-gnu         , withhold: withhold }
           - { os: windows-latest , target: i686-pc-windows-msvc        }
-          - { os: windows-latest , target: x86_64-pc-windows-gnu       }  ## note: requires rust >= 1.43.0 to link correctly
-          - { os: windows-latest , target: x86_64-pc-windows-msvc      }
+          - { os: windows-latest , target: x86_64-pc-windows-gnu       , withhold: withhold }  ## note: requires rust >= 1.43.0 to link correctly
+          - { os: windows-latest , target: x86_64-pc-windows-msvc      , withhold: withhold }
     steps:
       - uses: actions/checkout@v2
       - name: Install/setup prerequisites
@@ -339,8 +339,13 @@ jobs:
           PKG_BASENAME=${PROJECT_NAME}-${REF_TAG:-$REF_SHAS}-${{ matrix.job.target }}
           PKG_NAME=${PKG_BASENAME}${PKG_suffix}
           outputs PKG_suffix PKG_BASENAME PKG_NAME
-          # deployable tag? (ie, leading "vM" or "M"; M == version number)
-          unset DEPLOY ; if [[ $REF_TAG =~ ^[vV]?[0-9].* ]]; then DEPLOY='true' ; fi
+          # deployable?
+          unset DEPLOY
+          # * tagged for release? (ie, leading "vM" or "M"; M == version number)
+          if [[ $REF_TAG =~ ^[vV]?[0-9].* ]]; then
+            # gate DEPLOY upon NOT 'matrix.job.withhold' (truthy)
+            DEPLOY='true' ; case '${{ matrix.job.withhold }}' in '') ;; 0|f|false|n|no|off) ;; *) unset DEPLOY ;; esac;
+          fi
           outputs DEPLOY
           # DPKG architecture?
           unset DPKG_ARCH

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -495,95 +495,95 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  coverage:
-    name: Code Coverage
-    runs-on: ${{ matrix.job.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        job:
-          # { os }
-          - { os: ubuntu-latest }
-          - { os: macos-latest }
-          - { os: windows-latest }
-    steps:
-      - uses: actions/checkout@v2
-      # - name: Reattach HEAD ## may be needed for accurate code coverage info
-      #   run: git checkout ${{ github.head_ref }}
-      - name: Initialize workflow variables
-        id: vars
-        shell: bash
-        run: |
-          ## VARs setup
-          outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
-          # toolchain
-          TOOLCHAIN="nightly" ## default to "nightly" toolchain (required for certain required unstable compiler flags)
-          # * specify gnu-type TOOLCHAIN for windows; `grcov` requires gnu-style code coverage data files
-          case ${{ matrix.job.os }} in windows-*) TOOLCHAIN="$TOOLCHAIN-x86_64-pc-windows-gnu" ;; esac;
-          # * use requested TOOLCHAIN if specified
-          if [ -n "${{ matrix.job.toolchain }}" ]; then TOOLCHAIN="${{ matrix.job.toolchain }}" ; fi
-          outputs TOOLCHAIN
-          # staging directory
-          STAGING='_staging'
-          outputs STAGING
-          ## # check for CODECOV_TOKEN availability (work-around for inaccessible 'secrets' object for 'if'; see <https://github.community/t5/GitHub-Actions/jobs-lt-job-id-gt-if-does-not-work-with-env-secrets/m-p/38549>)
-          ## # note: CODECOV_TOKEN / HAS_CODECOV_TOKEN is not needed for public repositories when using AppVeyor, Azure Pipelines, CircleCI, GitHub Actions, Travis (see <https://docs.codecov.io/docs/about-the-codecov-bash-uploader#section-upload-token>)
-          ## unset HAS_CODECOV_TOKEN
-          ## if [ -n $CODECOV_TOKEN ]; then HAS_CODECOV_TOKEN='true' ; fi
-          ## outputs HAS_CODECOV_TOKEN
-          # target-specific options
-          # * CARGO_FEATURES_OPTION
-          unset CARGO_FEATURES_OPTION ;  ## default empty features option
-          if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
-          outputs CARGO_FEATURES_OPTION
-          # * CODECOV_FLAGS
-          CODECOV_FLAGS=$( echo "${{ matrix.job.os }}" | sed 's/[^[:alnum:]]/_/g' )
-          outputs CODECOV_FLAGS
-      - name: rust toolchain ~ install
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ steps.vars.outputs.TOOLCHAIN }}
-          default: true
-          profile: minimal # minimal component installation (ie, no documentation)
-      - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-fail-fast
-        env:
-          CARGO_INCREMENTAL: "0"
-          RUSTC_WRAPPER: ""
-          # RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'
-          RUSTFLAGS: "-Zprofile"
-          RUSTDOCFLAGS: "-Cpanic=abort"
-      - name: "`grcov` ~ install"
-        uses: actions-rs/install@v0.1
-        with:
-          crate: grcov
-          version: latest
-          use-tool-cache: false
-      - name: Generate coverage data (via `grcov`)
-        id: coverage
-        shell: bash
-        run: |
-          ## Generate coverage data
-          COVERAGE_REPORT_DIR="target/debug"
-          COVERAGE_REPORT_FILE="${COVERAGE_REPORT_DIR}/lcov.info"
-          # GRCOV_IGNORE_OPTION='--ignore build.rs --ignore "/*" --ignore "[a-zA-Z]:/*"' ## `grcov` ignores these params when passed as an environment variable (why?)
-          # GRCOV_EXCLUDE_OPTION='--excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"' ## `grcov` ignores these params when passed as an environment variable (why?)
-          mkdir -p "${COVERAGE_REPORT_DIR}"
-          # display coverage files
-          grcov . --output-type files --ignore build.rs --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()" | sort --unique
-          # generate coverage report
-          grcov . --output-type lcov --output-path "${COVERAGE_REPORT_FILE}" --branch --ignore build.rs --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"
-          echo ::set-output name=report::${COVERAGE_REPORT_FILE}
-      - name: Upload coverage results (to Codecov.io)
-        uses: codecov/codecov-action@v1
-        # if: steps.vars.outputs.HAS_CODECOV_TOKEN
-        with:
-          # token: ${{ secrets.CODECOV_TOKEN }}
-          file: ${{ steps.coverage.outputs.report }}
-          ## flags: IntegrationTests, UnitTests, ${{ steps.vars.outputs.CODECOV_FLAGS }}
-          flags: ${{ steps.vars.outputs.CODECOV_FLAGS }}
-          name: codecov-umbrella
-          fail_ci_if_error: false
+  # coverage:
+  #   name: Code Coverage
+  #   runs-on: ${{ matrix.job.os }}
+  #   strategy:
+  #     fail-fast: true
+  #     matrix:
+  #       job:
+  #         # { os }
+  #         - { os: ubuntu-latest }
+  #         - { os: macos-latest }
+  #         - { os: windows-latest }
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     # - name: Reattach HEAD ## may be needed for accurate code coverage info
+  #     #   run: git checkout ${{ github.head_ref }}
+  #     - name: Initialize workflow variables
+  #       id: vars
+  #       shell: bash
+  #       run: |
+  #         ## VARs setup
+  #         outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+  #         # toolchain
+  #         TOOLCHAIN="nightly" ## default to "nightly" toolchain (required for certain required unstable compiler flags)
+  #         # * specify gnu-type TOOLCHAIN for windows; `grcov` requires gnu-style code coverage data files
+  #         case ${{ matrix.job.os }} in windows-*) TOOLCHAIN="$TOOLCHAIN-x86_64-pc-windows-gnu" ;; esac;
+  #         # * use requested TOOLCHAIN if specified
+  #         if [ -n "${{ matrix.job.toolchain }}" ]; then TOOLCHAIN="${{ matrix.job.toolchain }}" ; fi
+  #         outputs TOOLCHAIN
+  #         # staging directory
+  #         STAGING='_staging'
+  #         outputs STAGING
+  #         ## # check for CODECOV_TOKEN availability (work-around for inaccessible 'secrets' object for 'if'; see <https://github.community/t5/GitHub-Actions/jobs-lt-job-id-gt-if-does-not-work-with-env-secrets/m-p/38549>)
+  #         ## # note: CODECOV_TOKEN / HAS_CODECOV_TOKEN is not needed for public repositories when using AppVeyor, Azure Pipelines, CircleCI, GitHub Actions, Travis (see <https://docs.codecov.io/docs/about-the-codecov-bash-uploader#section-upload-token>)
+  #         ## unset HAS_CODECOV_TOKEN
+  #         ## if [ -n $CODECOV_TOKEN ]; then HAS_CODECOV_TOKEN='true' ; fi
+  #         ## outputs HAS_CODECOV_TOKEN
+  #         # target-specific options
+  #         # * CARGO_FEATURES_OPTION
+  #         unset CARGO_FEATURES_OPTION ;  ## default empty features option
+  #         if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
+  #         outputs CARGO_FEATURES_OPTION
+  #         # * CODECOV_FLAGS
+  #         CODECOV_FLAGS=$( echo "${{ matrix.job.os }}" | sed 's/[^[:alnum:]]/_/g' )
+  #         outputs CODECOV_FLAGS
+  #     - name: rust toolchain ~ install
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: ${{ steps.vars.outputs.TOOLCHAIN }}
+  #         default: true
+  #         profile: minimal # minimal component installation (ie, no documentation)
+  #     - name: Test
+  #       uses: actions-rs/cargo@v1
+  #       with:
+  #         command: test
+  #         args: ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-fail-fast
+  #       env:
+  #         CARGO_INCREMENTAL: "0"
+  #         RUSTC_WRAPPER: ""
+  #         # RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'
+  #         RUSTFLAGS: "-Zprofile"
+  #         RUSTDOCFLAGS: "-Cpanic=abort"
+  #     - name: "`grcov` ~ install"
+  #       uses: actions-rs/install@v0.1
+  #       with:
+  #         crate: grcov
+  #         version: latest
+  #         use-tool-cache: false
+  #     - name: Generate coverage data (via `grcov`)
+  #       id: coverage
+  #       shell: bash
+  #       run: |
+  #         ## Generate coverage data
+  #         COVERAGE_REPORT_DIR="target/debug"
+  #         COVERAGE_REPORT_FILE="${COVERAGE_REPORT_DIR}/lcov.info"
+  #         # GRCOV_IGNORE_OPTION='--ignore build.rs --ignore "/*" --ignore "[a-zA-Z]:/*"' ## `grcov` ignores these params when passed as an environment variable (why?)
+  #         # GRCOV_EXCLUDE_OPTION='--excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"' ## `grcov` ignores these params when passed as an environment variable (why?)
+  #         mkdir -p "${COVERAGE_REPORT_DIR}"
+  #         # display coverage files
+  #         grcov . --output-type files --ignore build.rs --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()" | sort --unique
+  #         # generate coverage report
+  #         grcov . --output-type lcov --output-path "${COVERAGE_REPORT_FILE}" --branch --ignore build.rs --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"
+  #         echo ::set-output name=report::${COVERAGE_REPORT_FILE}
+  #     - name: Upload coverage results (to Codecov.io)
+  #       uses: codecov/codecov-action@v1
+  #       # if: steps.vars.outputs.HAS_CODECOV_TOKEN
+  #       with:
+  #         # token: ${{ secrets.CODECOV_TOKEN }}
+  #         file: ${{ steps.coverage.outputs.report }}
+  #         ## flags: IntegrationTests, UnitTests, ${{ steps.vars.outputs.CODECOV_FLAGS }}
+  #         flags: ${{ steps.vars.outputs.CODECOV_FLAGS }}
+  #         name: codecov-umbrella
+  #         fail_ci_if_error: false

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1,0 +1,584 @@
+name: CICD
+
+# spell-checker:ignore (acronyms) CICD MSRV MSVC musl
+# spell-checker:ignore (env/flags) Awarnings Ccodegen Coverflow Cpanic RUSTDOCFLAGS RUSTFLAGS Zpanic
+# spell-checker:ignore (jargon) SHAs deps softprops toolchain
+# spell-checker:ignore (misc) aarch alnum armhf gnueabihf maint
+# spell-checker:ignore (names) CodeCOV MacOS MinGW
+# spell-checker:ignore (people) Aram Drevekenin * imsnif , Roy Ivy III * rivy
+# spell-checker:ignore (shell/tools) choco clippy dmake dpkg esac fakeroot gmake grcov halium lcov libssl mkdir nullglob popd printf pushd rustc rustfmt rustup shopt xargs
+
+# spell-checker:ignore diskonaut
+
+env:
+  PROJECT_NAME: diskonaut
+  PROJECT_DESC: "Terminal disk space navigator 🔭"
+  PROJECT_AUTH: "imsnif"
+  RUST_MIN_SRV: "1.43.0" ## minimum supported rust version (aka, MinSRV or MSRV)
+  # * style job configuration
+  STYLE_FAIL_ON_FAULT: true ## fail the build if a style job contains a fault (error or warning)?
+
+on: [push, pull_request]
+
+jobs:
+  style_format:
+    name: Style/format
+    runs-on: ${{ matrix.job.os }}
+    # env:
+    #   STYLE_FAIL_ON_FAULT: false # overrides workflow default
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          # { os }
+          - { os: ubuntu-latest }
+    steps:
+      - uses: actions/checkout@v2
+      - name: Initialize workflow variables
+        id: vars
+        shell: bash
+        run: |
+          ## VARs setup
+          outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+          # failure mode
+          unset FAIL_ON_FAULT ; case '${{ env.STYLE_FAIL_ON_FAULT }}' in
+            ''|0|f|false|n|no|off) FAULT_TYPE=warning ;;
+            *) FAIL_ON_FAULT=true ; FAULT_TYPE=error ;;
+          esac;
+          outputs FAIL_ON_FAULT FAULT_TYPE
+          # target-specific options
+          # * CARGO_FEATURES_OPTION
+          unset CARGO_FEATURES_OPTION
+          if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
+          outputs CARGO_FEATURES_OPTION
+      - name: Install `rust` toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          profile: minimal # minimal component installation (ie, no documentation)
+          components: rustfmt
+      - name: "`cargo fmt` testing"
+        shell: bash
+        run: |
+          ## `cargo fmt` testing
+          unset fault
+          fault_type="${{ steps.vars.outputs.FAULT_TYPE }}"
+          fault_prefix=$(echo "$fault_type" | tr '[:lower:]' '[:upper:]')
+          # * convert any errors/warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>
+          S=$(cargo fmt -- --check) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s\n" "$S" | sed -E -n -e "s/^Diff[[:space:]]+in[[:space:]]+${PWD//\//\\/}\/(.*)[[:space:]]+at[[:space:]]+[^0-9]+([0-9]+).*$/::${fault_type} file=\1,line=\2::${fault_prefix}: \`cargo fmt\`: style violation (file:'\1', line:\2; use \`cargo fmt -- \"\1\"\`)/p" ; fault=true ; }
+          if [ -n "${{ steps.vars.outputs.FAIL_ON_FAULT }}" ] && [ -n "$fault" ]; then exit 1 ; fi
+      - name: "`cargo fmt` testing of integration tests"
+        if: success() || failure() # run regardless of prior step success/failure
+        shell: bash
+        run: |
+          ## `cargo fmt` testing of integration tests
+          unset fault
+          fault_type="${{ steps.vars.outputs.FAULT_TYPE }}"
+          fault_prefix=$(echo "$fault_type" | tr '[:lower:]' '[:upper:]')
+          # 'tests' is the standard/usual integration test directory
+          if [ -d tests ]; then
+            # * convert any errors/warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>
+            S=$(find tests -name "*.rs" -print0 | xargs -0 cargo fmt -- --check) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s\n" "$S" | sed -E -n "s/^Diff[[:space:]]+in[[:space:]]+${PWD//\//\\/}\/(.*)[[:space:]]+at[[:space:]]+[^0-9]+([0-9]+).*$/::${fault_type} file=\1,line=\2::${fault_prefix}: \`cargo fmt\`: style violation (file:'\1', line:\2; use \`cargo fmt \"\1\"\`)/p" ; fault=true ; }
+          fi
+          if [ -n "${{ steps.vars.outputs.FAIL_ON_FAULT }}" ] && [ -n "$fault" ]; then exit 1 ; fi
+
+  style_lint:
+    name: Style/lint
+    runs-on: ${{ matrix.job.os }}
+    env:
+      STYLE_FAIL_ON_FAULT: false # overrides workflow default
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          # { os }
+          - { os: ubuntu-latest }
+          - { os: macos-latest }
+          - { os: windows-latest }
+    steps:
+      - uses: actions/checkout@v2
+      - name: Initialize workflow variables
+        id: vars
+        shell: bash
+        run: |
+          ## VARs setup
+          outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+          # failure mode
+          unset FAIL_ON_FAULT ; case '${{ env.STYLE_FAIL_ON_FAULT }}' in
+            ''|0|f|false|n|no|off) FAULT_TYPE=warning ;;
+            *) FAIL_ON_FAULT=true ; FAULT_TYPE=error ;;
+          esac;
+          outputs FAIL_ON_FAULT FAULT_TYPE
+          # target-specific options
+          # * CARGO_FEATURES_OPTION
+          unset CARGO_FEATURES_OPTION
+          if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
+          outputs CARGO_FEATURES_OPTION
+      - name: Install `rust` toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          profile: minimal # minimal component installation (ie, no documentation)
+          components: clippy
+      - name: "`cargo clippy` lint testing"
+        shell: bash
+        run: |
+          ## `cargo clippy` lint testing
+          unset fault
+          fault_type="${{ steps.vars.outputs.FAULT_TYPE }}"
+          fault_prefix=$(echo "$fault_type" | tr '[:lower:]' '[:upper:]')
+          # * convert any warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>
+          S=$(cargo clippy --all-targets ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -- -D warnings 2>&1) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n -e '/^error:/{' -e "N; s/^error:[[:space:]]+(.*)\\n[[:space:]]+-->[[:space:]]+(.*):([0-9]+):([0-9]+).*$/::${fault_type} file=\2,line=\3,col=\4::${fault_prefix}: \`cargo clippy\`: \1 (file:'\2', line:\3)/p;" -e '}' ; fault=true ; }
+          if [ -n "${{ steps.vars.outputs.FAIL_ON_FAULT }}" ] && [ -n "$fault" ]; then exit 1 ; fi
+
+  style_spellcheck:
+    name: Style/spelling
+    runs-on: ${{ matrix.job.os }}
+    env:
+      STYLE_FAIL_ON_FAULT: false # overrides workflow default
+    strategy:
+      matrix:
+        job:
+          - { os: ubuntu-latest }
+    steps:
+      - uses: actions/checkout@v2
+      - name: Initialize workflow variables
+        id: vars
+        shell: bash
+        run: |
+          ## VARs setup
+          outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+          # failure mode
+          unset FAIL_ON_FAULT ; case '${{ env.STYLE_FAIL_ON_FAULT }}' in
+            ''|0|f|false|n|no|off) FAULT_TYPE=warning ;;
+            *) FAIL_ON_FAULT=true ; FAULT_TYPE=error ;;
+          esac;
+          outputs FAIL_ON_FAULT FAULT_TYPE
+      - name: Install/setup prerequisites
+        shell: bash
+        run: |
+          ## Install/setup prerequisites
+          sudo apt-get -y update ; sudo apt-get -y install npm ; sudo npm install cspell -g ;
+      - name: Run `cspell`
+        shell: bash
+        run: |
+          ## Run `cspell`
+          unset fault
+          fault_type="${{ steps.vars.outputs.FAULT_TYPE }}"
+          fault_prefix=$(echo "$fault_type" | tr '[:lower:]' '[:upper:]')
+          # * find cspell configuration
+          cfg_files=($(shopt -s nullglob ; echo {.vscode,.}/{,.}c[sS]pell{.json,.config{.js,.cjs,.json,.yaml,.yml},.yaml,.yml} ;))
+          cfg_file=${cfg_files[0]}
+          unset CSPELL_CFG_OPTION ; if [ -n "$cfg_file" ]; then CSPELL_CFG_OPTION="--config \"$cfg_file\"" ; fi
+          # * `cspell`
+          S=$(cspell ${CSPELL_CFG_OPTION} --no-summary --no-progress "**/*") && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n "s/${PWD//\//\\/}\/(.*):(.*):(.*) - (.*)/::${fault_type} file=\1,line=\2,col=\3::${fault_type^^}: \4 (file:'\1', line:\2)/p" ; fault=true ; true ; }
+          if [ -n "${{ steps.vars.outputs.FAIL_ON_FAULT }}" ] && [ -n "$fault" ]; then exit 1 ; fi
+
+  min_version:
+    name: MinRustV # Minimum supported rust version (aka, MinSRV or MSRV)
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      matrix:
+        job:
+          # { os, features }
+          - { os: ubuntu-latest }
+    steps:
+      - uses: actions/checkout@v2
+      - name: Initialize workflow variables
+        id: vars
+        shell: bash
+        run: |
+          ## VARs setup
+          outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+          # target-specific options
+          # * CARGO_FEATURES_OPTION
+          unset CARGO_FEATURES_OPTION
+          if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
+          outputs CARGO_FEATURES_OPTION
+      - name: Install `rust` toolchain (v${{ env.RUST_MIN_SRV }})
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.RUST_MIN_SRV }}
+          default: true
+          profile: minimal # minimal component installation (ie, no documentation)
+      - name: Install `cargo-tree` # for dependency information
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-tree
+          version: latest
+          use-tool-cache: true
+        env:
+          RUSTUP_TOOLCHAIN: stable
+      - name: Confirm MinSRV compatible 'Cargo.lock'
+        shell: bash
+        run: |
+          ## Confirm MinSRV compatible 'Cargo.lock'
+          # * 'Cargo.lock' is required to be in a format that `cargo` of MinSRV can interpret (eg, v1-format for MinSRV < v1.38)
+          cargo fetch --locked --quiet || { echo "::error file=Cargo.lock::Incompatible (or out-of-date) 'Cargo.lock' file; update using \`cargo +${{ env.RUST_MIN_SRV }} update\`" ; exit 1 ; }
+      - name: Info
+        shell: bash
+        run: |
+          ## Info
+          # environment
+          echo "## environment"
+          echo "CI='${CI}'"
+          # tooling info display
+          echo "## tooling"
+          which gcc >/dev/null 2>&1 && (gcc --version | head -1) || true
+          rustup -V 2>/dev/null
+          rustup show active-toolchain
+          cargo -V
+          rustc -V
+          cargo-tree tree -V
+          # dependencies
+          echo "## dependency list"
+          ## * using the 'stable' toolchain is necessary to avoid "unexpected '--filter-platform'" errors
+          RUSTUP_TOOLCHAIN=stable cargo fetch --locked --quiet
+          RUSTUP_TOOLCHAIN=stable cargo-tree tree --all --locked --no-dev-dependencies --no-indent ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} | grep -vE "$PWD" | sort --unique
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+        env:
+          RUSTFLAGS: '-Awarnings'
+
+  deps:
+    name: Dependencies
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          - { os: ubuntu-latest }
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install `rust` toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          profile: minimal # minimal component installation (ie, no documentation)
+      - name: "`cargo update` testing"
+        shell: bash
+        run: |
+          ## `cargo update` testing
+          # * convert any errors/warnings to GHA UI annotations; ref: <https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-warning-message>
+          cargo fetch --locked --quiet || { echo "::error file=Cargo.lock::'Cargo.lock' file requires update (use \`cargo +${{ env.RUST_MIN_SRV }} update\`)" ; exit 1 ; }
+
+  build:
+    name: Build
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          # { os, target, cargo-options, features, use-cross, toolchain }
+          ## - { os: ubuntu-latest  , target: arm-unknown-linux-gnueabihf , use-cross: use-cross }
+          ## - { os: ubuntu-latest  , target: aarch64-unknown-linux-gnu   , use-cross: use-cross }
+          - { os: ubuntu-latest  , target: i686-unknown-linux-gnu      , use-cross: use-cross }
+          - { os: ubuntu-latest  , target: i686-unknown-linux-musl     , use-cross: use-cross }
+          - { os: ubuntu-latest  , target: x86_64-unknown-linux-gnu    , use-cross: use-cross }
+          - { os: ubuntu-latest  , target: x86_64-unknown-linux-musl   , use-cross: use-cross }
+          - { os: macos-latest   , target: x86_64-apple-darwin         }
+          - { os: windows-latest , target: i686-pc-windows-gnu         }
+          - { os: windows-latest , target: i686-pc-windows-msvc        }
+          - { os: windows-latest , target: x86_64-pc-windows-gnu       }  ## note: requires rust >= 1.43.0 to link correctly
+          - { os: windows-latest , target: x86_64-pc-windows-msvc      }
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install/setup prerequisites
+        shell: bash
+        run: |
+          ## Install/setup prerequisites
+          case '${{ matrix.job.target }}' in
+            arm-unknown-linux-gnueabihf) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
+            aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
+          esac
+      - name: Initialize workflow variables
+        id: vars
+        shell: bash
+        run: |
+          ## VARs setup
+          outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+          # toolchain
+          TOOLCHAIN="stable" ## default to "stable" toolchain
+          # * specify alternate/non-default TOOLCHAIN for *-pc-windows-gnu targets; gnu targets on Windows are broken for the standard *-pc-windows-msvc toolchain (refs: GH:rust-lang/rust#47048, GH:rust-lang/rust#53454, GH:rust-lang/cargo#6754)
+          case ${{ matrix.job.target }} in *-pc-windows-gnu) TOOLCHAIN="stable-${{ matrix.job.target }}" ;; esac;
+          # * use requested TOOLCHAIN if specified
+          if [ -n "${{ matrix.job.toolchain }}" ]; then TOOLCHAIN="${{ matrix.job.toolchain }}" ; fi
+          outputs TOOLCHAIN
+          # staging directory
+          STAGING='_staging'
+          outputs STAGING
+          # determine EXE suffix
+          EXE_suffix="" ; case '${{ matrix.job.target }}' in *-pc-windows-*) EXE_suffix=".exe" ;; esac;
+          outputs EXE_suffix
+          # parse commit reference info
+          echo GITHUB_REF=${GITHUB_REF}
+          echo GITHUB_SHA=${GITHUB_SHA}
+          REF_NAME=${GITHUB_REF#refs/*/}
+          unset REF_BRANCH ; case "${GITHUB_REF}" in refs/heads/*) REF_BRANCH=${GITHUB_REF#refs/heads/} ;; esac;
+          unset REF_TAG ; case "${GITHUB_REF}" in refs/tags/*) REF_TAG=${GITHUB_REF#refs/tags/} ;; esac;
+          REF_SHAS=${GITHUB_SHA:0:8}
+          outputs REF_NAME REF_BRANCH REF_TAG REF_SHAS
+          # parse target info
+          unset TARGET_ARCH
+          case '${{ matrix.job.target }}' in
+            aarch64-*) TARGET_ARCH=arm64 ;;
+            arm-*-*hf) TARGET_ARCH=armhf ;;
+            i586-*) TARGET_ARCH=i586 ;;
+            i686-*) TARGET_ARCH=i686 ;;
+            x86_64-*) TARGET_ARCH=x86_64 ;;
+          esac;
+          unset TARGET_OS ; case '${{ matrix.job.target }}' in *-linux-*) TARGET_OS=linux ;; *-apple-*) TARGET_OS=macos ;; *-windows-*) TARGET_OS=windows ;; esac;
+          outputs TARGET_ARCH TARGET_OS
+          # package name
+          PKG_suffix=".tar.gz" ; case '${{ matrix.job.target }}' in *-pc-windows-*) PKG_suffix=".zip" ;; esac;
+          PKG_BASENAME=${PROJECT_NAME}-${REF_TAG:-$REF_SHAS}-${{ matrix.job.target }}
+          PKG_NAME=${PKG_BASENAME}${PKG_suffix}
+          outputs PKG_suffix PKG_BASENAME PKG_NAME
+          # deployable tag? (ie, leading "vM" or "M"; M == version number)
+          unset DEPLOY ; if [[ $REF_TAG =~ ^[vV]?[0-9].* ]]; then DEPLOY='true' ; fi
+          outputs DEPLOY
+          # DPKG architecture?
+          unset DPKG_ARCH
+          case ${{ matrix.job.target }} in
+            x86_64-*-linux-*) DPKG_ARCH=amd64 ;;
+            *-linux-*) DPKG_ARCH=${TARGET_ARCH} ;;
+          esac
+          outputs DPKG_ARCH
+          # DPKG version?
+          unset DPKG_VERSION ; if [[ $REF_TAG =~ ^[vV]?[0-9].* ]]; then DPKG_VERSION=${REF_TAG/#[vV]/} ; fi
+          outputs DPKG_VERSION
+          # DPKG base name/conflicts?
+          DPKG_BASENAME=${PROJECT_NAME}
+          DPKG_CONFLICTS=${PROJECT_NAME}-musl
+          case ${{ matrix.job.target }} in *-musl) DPKG_BASENAME=${PROJECT_NAME}-musl ; DPKG_CONFLICTS=${PROJECT_NAME} ;; esac;
+          outputs DPKG_BASENAME DPKG_CONFLICTS
+          # DPKG name
+          unset DPKG_NAME
+          if [[ -n $DPKG_ARCH && -n $DPKG_VERSION ]]; then DPKG_NAME="${DPKG_BASENAME}_${DPKG_VERSION}_${DPKG_ARCH}.deb" ; fi
+          outputs DPKG_NAME
+          # target-specific options
+          # * CARGO_FEATURES_OPTION
+          unset CARGO_FEATURES_OPTION
+          if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
+          outputs CARGO_FEATURES_OPTION
+          # * CARGO_USE_CROSS (truthy)
+          CARGO_USE_CROSS='true' ; case '${{ matrix.job.use-cross }}' in '') unset CARGO_USE_CROSS ;; 0|f|false|n|no|off) unset CARGO_USE_CROSS ;; esac;
+          outputs CARGO_USE_CROSS
+          # ** pass needed environment into `cross` container (iff `cross` not already configured via "Cross.toml")
+          if [ -n "${CARGO_USE_CROSS}" ] && [ ! -e "Cross.toml" ] ; then
+            printf "[build.env]\npassthrough = [\"CI\"]\n" > Cross.toml
+          fi
+          # * test only library and/or binaries for arm-type targets
+          unset CARGO_TEST_OPTIONS ; case '${{ matrix.job.target }}' in aarch64-* | arm-*) CARGO_TEST_OPTIONS="--bins" ;; esac;
+          outputs CARGO_TEST_OPTIONS
+          # * executable for `strip`?
+          STRIP="strip"
+          case ${{ matrix.job.target }} in
+            aarch64-*-linux-gnu) STRIP="aarch64-linux-gnu-strip" ;;
+            arm-*-linux-gnueabihf) STRIP="arm-linux-gnueabihf-strip" ;;
+            *-pc-windows-msvc) STRIP="" ;;
+          esac;
+          outputs STRIP
+      - name: Create all needed build/work directories
+        shell: bash
+        run: |
+          ## Create build/work space
+          mkdir -p '${{ steps.vars.outputs.STAGING }}'
+          mkdir -p '${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_BASENAME }}'
+          mkdir -p '${{ steps.vars.outputs.STAGING }}/dpkg'
+      - name: rust toolchain ~ install
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ steps.vars.outputs.TOOLCHAIN }}
+          target: ${{ matrix.job.target }}
+          default: true
+          profile: minimal # minimal component installation (ie, no documentation)
+      - name: Install `cargo-tree` # for dependency information
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-tree
+          version: latest
+          use-tool-cache: true
+        env:
+          RUSTUP_TOOLCHAIN: stable
+      - name: Info
+        shell: bash
+        run: |
+          ## Info
+          # commit info
+          echo "## commit"
+          echo GITHUB_REF=${GITHUB_REF}
+          echo GITHUB_SHA=${GITHUB_SHA}
+          # environment
+          echo "## environment"
+          echo "CI='${CI}'"
+          # tooling info display
+          echo "## tooling"
+          which gcc >/dev/null 2>&1 && (gcc --version | head -1) || true
+          rustup -V 2>/dev/null
+          rustup show active-toolchain
+          cargo -V
+          rustc -V
+          cargo-tree tree -V
+          # dependencies
+          echo "## dependency list"
+          cargo fetch --locked --quiet
+          cargo-tree tree --locked --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --all --no-dev-dependencies --no-indent | grep -vE "$PWD" | sort --unique
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: ${{ steps.vars.outputs.CARGO_USE_CROSS }}
+          command: build
+          args: --release --target=${{ matrix.job.target }} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: ${{ steps.vars.outputs.CARGO_USE_CROSS }}
+          command: test
+          args: --target=${{ matrix.job.target }} ${{ steps.vars.outputs.CARGO_TEST_OPTIONS}} ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }}
+      - name: Archive executable artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.PROJECT_NAME }}-${{ matrix.job.target }}
+          path: target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}
+      - name: Package
+        shell: bash
+        run: |
+          ## Package artifact(s)
+          # binary
+          cp 'target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}' '${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_BASENAME }}/'
+          # `strip` binary (if needed)
+          if [ -n "${{ steps.vars.outputs.STRIP }}" ]; then "${{ steps.vars.outputs.STRIP }}" '${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_BASENAME }}/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}' ; fi
+          # README and LICENSE
+          # * spell-checker:ignore EADME ICENSE
+          (shopt -s nullglob; for f in [R]"EADME"{,.*}; do cp $f '${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_BASENAME }}/' ; done)
+          (shopt -s nullglob; for f in [L]"ICENSE"{-*,}{,.*}; do cp $f '${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_BASENAME }}/' ; done)
+          # core compressed package
+          pushd '${{ steps.vars.outputs.STAGING }}/' >/dev/null
+          case '${{ matrix.job.target }}' in
+            *-pc-windows-*) 7z -y a '${{ steps.vars.outputs.PKG_NAME }}' '${{ steps.vars.outputs.PKG_BASENAME }}'/* | tail -2 ;;
+            *) tar czf '${{ steps.vars.outputs.PKG_NAME }}' '${{ steps.vars.outputs.PKG_BASENAME }}'/* ;;
+          esac
+          popd >/dev/null
+          # dpkg
+          if [ -n "${{ steps.vars.outputs.DPKG_NAME }}" ]; then
+            DPKG_DIR="${{ steps.vars.outputs.STAGING }}/dpkg"
+            # binary
+            install -Dm755 'target/${{ matrix.job.target }}/release/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}' "${DPKG_DIR}/usr/bin/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}"
+            if [ -n "${{ steps.vars.outputs.STRIP }}" ]; then "${{ steps.vars.outputs.STRIP }}" "${DPKG_DIR}/usr/bin/${{ env.PROJECT_NAME }}${{ steps.vars.outputs.EXE_suffix }}" ; fi
+            # README and LICENSE
+            (shopt -s nullglob; for f in [R]"EADME"{,.*}; do install -Dm644 "$f" "${DPKG_DIR}/usr/share/doc/${{ env.PROJECT_NAME }}/$f" ; done)
+            (shopt -s nullglob; for f in [L]"ICENSE"{-*,}{,.*}; do install -Dm644 "$f" "${DPKG_DIR}/usr/share/doc/${{ env.PROJECT_NAME }}/$f" ; done)
+            # control file
+            mkdir -p "${DPKG_DIR}/DEBIAN"
+            printf "Package: ${{ steps.vars.outputs.DPKG_BASENAME }}\nVersion: ${{ steps.vars.outputs.DPKG_VERSION }}\nSection: utils\nPriority: optional\nMaintainer: ${{ env.PROJECT_AUTH }}\nArchitecture: ${{ steps.vars.outputs.DPKG_ARCH }}\nProvides: ${{ env.PROJECT_NAME }}\nConflicts: ${{ steps.vars.outputs.DPKG_CONFLICTS }}\nDescription: ${{ env.PROJECT_DESC }}\n" > "${DPKG_DIR}/DEBIAN/control"
+            # build dpkg
+            fakeroot dpkg-deb --build "${DPKG_DIR}" "${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.DPKG_NAME }}"
+          fi
+      - name: Publish
+        uses: softprops/action-gh-release@v1
+        if: steps.vars.outputs.DEPLOY
+        with:
+          files: |
+            ${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.PKG_NAME }}
+            ${{ steps.vars.outputs.STAGING }}/${{ steps.vars.outputs.DPKG_NAME }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  coverage:
+    name: Code Coverage
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        job:
+          # { os }
+          - { os: ubuntu-latest }
+          - { os: macos-latest }
+          - { os: windows-latest }
+    steps:
+      - uses: actions/checkout@v2
+      # - name: Reattach HEAD ## may be needed for accurate code coverage info
+      #   run: git checkout ${{ github.head_ref }}
+      - name: Initialize workflow variables
+        id: vars
+        shell: bash
+        run: |
+          ## VARs setup
+          outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+          # toolchain
+          TOOLCHAIN="nightly" ## default to "nightly" toolchain (required for certain required unstable compiler flags)
+          # * specify gnu-type TOOLCHAIN for windows; `grcov` requires gnu-style code coverage data files
+          case ${{ matrix.job.os }} in windows-*) TOOLCHAIN="$TOOLCHAIN-x86_64-pc-windows-gnu" ;; esac;
+          # * use requested TOOLCHAIN if specified
+          if [ -n "${{ matrix.job.toolchain }}" ]; then TOOLCHAIN="${{ matrix.job.toolchain }}" ; fi
+          outputs TOOLCHAIN
+          # staging directory
+          STAGING='_staging'
+          outputs STAGING
+          ## # check for CODECOV_TOKEN availability (work-around for inaccessible 'secrets' object for 'if'; see <https://github.community/t5/GitHub-Actions/jobs-lt-job-id-gt-if-does-not-work-with-env-secrets/m-p/38549>)
+          ## # note: CODECOV_TOKEN / HAS_CODECOV_TOKEN is not needed for public repositories when using AppVeyor, Azure Pipelines, CircleCI, GitHub Actions, Travis (see <https://docs.codecov.io/docs/about-the-codecov-bash-uploader#section-upload-token>)
+          ## unset HAS_CODECOV_TOKEN
+          ## if [ -n $CODECOV_TOKEN ]; then HAS_CODECOV_TOKEN='true' ; fi
+          ## outputs HAS_CODECOV_TOKEN
+          # target-specific options
+          # * CARGO_FEATURES_OPTION
+          unset CARGO_FEATURES_OPTION ;  ## default empty features option
+          if [ -n "${{ matrix.job.features }}" ]; then CARGO_FEATURES_OPTION='--features "${{ matrix.job.features }}"' ; fi
+          outputs CARGO_FEATURES_OPTION
+          # * CODECOV_FLAGS
+          CODECOV_FLAGS=$( echo "${{ matrix.job.os }}" | sed 's/[^[:alnum:]]/_/g' )
+          outputs CODECOV_FLAGS
+      - name: rust toolchain ~ install
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ steps.vars.outputs.TOOLCHAIN }}
+          default: true
+          profile: minimal # minimal component installation (ie, no documentation)
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-fail-fast
+        env:
+          CARGO_INCREMENTAL: "0"
+          RUSTC_WRAPPER: ""
+          # RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'
+          RUSTFLAGS: "-Zprofile"
+          RUSTDOCFLAGS: "-Cpanic=abort"
+      - name: "`grcov` ~ install"
+        uses: actions-rs/install@v0.1
+        with:
+          crate: grcov
+          version: latest
+          use-tool-cache: false
+      - name: Generate coverage data (via `grcov`)
+        id: coverage
+        shell: bash
+        run: |
+          ## Generate coverage data
+          COVERAGE_REPORT_DIR="target/debug"
+          COVERAGE_REPORT_FILE="${COVERAGE_REPORT_DIR}/lcov.info"
+          # GRCOV_IGNORE_OPTION='--ignore build.rs --ignore "/*" --ignore "[a-zA-Z]:/*"' ## `grcov` ignores these params when passed as an environment variable (why?)
+          # GRCOV_EXCLUDE_OPTION='--excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"' ## `grcov` ignores these params when passed as an environment variable (why?)
+          mkdir -p "${COVERAGE_REPORT_DIR}"
+          # display coverage files
+          grcov . --output-type files --ignore build.rs --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()" | sort --unique
+          # generate coverage report
+          grcov . --output-type lcov --output-path "${COVERAGE_REPORT_FILE}" --branch --ignore build.rs --ignore "/*" --ignore "[a-zA-Z]:/*" --excl-br-line "^\s*((debug_)?assert(_eq|_ne)?!|#\[derive\()"
+          echo ::set-output name=report::${COVERAGE_REPORT_FILE}
+      - name: Upload coverage results (to Codecov.io)
+        uses: codecov/codecov-action@v1
+        # if: steps.vars.outputs.HAS_CODECOV_TOKEN
+        with:
+          # token: ${{ secrets.CODECOV_TOKEN }}
+          file: ${{ steps.coverage.outputs.report }}
+          ## flags: IntegrationTests, UnitTests, ${{ steps.vars.outputs.CODECOV_FLAGS }}
+          flags: ${{ steps.vars.outputs.CODECOV_FLAGS }}
+          name: codecov-umbrella
+          fail_ci_if_error: false

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -86,8 +86,8 @@ jobs:
   style_lint:
     name: Style/lint
     runs-on: ${{ matrix.job.os }}
-    env:
-      STYLE_FAIL_ON_FAULT: false # overrides workflow default
+    # env:
+    #   STYLE_FAIL_ON_FAULT: false # overrides workflow default
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -133,48 +133,48 @@ jobs:
           S=$(cargo clippy --all-targets ${{ matrix.job.cargo-options }} ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} -- -D warnings 2>&1) && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n -e '/^error:/{' -e "N; s/^error:[[:space:]]+(.*)\\n[[:space:]]+-->[[:space:]]+(.*):([0-9]+):([0-9]+).*$/::${fault_type} file=\2,line=\3,col=\4::${fault_prefix}: \`cargo clippy\`: \1 (file:'\2', line:\3)/p;" -e '}' ; fault=true ; }
           if [ -n "${{ steps.vars.outputs.FAIL_ON_FAULT }}" ] && [ -n "$fault" ]; then exit 1 ; fi
 
-  style_spellcheck:
-    name: Style/spelling
-    runs-on: ${{ matrix.job.os }}
-    env:
-      STYLE_FAIL_ON_FAULT: false # overrides workflow default
-    strategy:
-      matrix:
-        job:
-          - { os: ubuntu-latest }
-    steps:
-      - uses: actions/checkout@v2
-      - name: Initialize workflow variables
-        id: vars
-        shell: bash
-        run: |
-          ## VARs setup
-          outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
-          # failure mode
-          unset FAIL_ON_FAULT ; case '${{ env.STYLE_FAIL_ON_FAULT }}' in
-            ''|0|f|false|n|no|off) FAULT_TYPE=warning ;;
-            *) FAIL_ON_FAULT=true ; FAULT_TYPE=error ;;
-          esac;
-          outputs FAIL_ON_FAULT FAULT_TYPE
-      - name: Install/setup prerequisites
-        shell: bash
-        run: |
-          ## Install/setup prerequisites
-          sudo apt-get -y update ; sudo apt-get -y install npm ; sudo npm install cspell -g ;
-      - name: Run `cspell`
-        shell: bash
-        run: |
-          ## Run `cspell`
-          unset fault
-          fault_type="${{ steps.vars.outputs.FAULT_TYPE }}"
-          fault_prefix=$(echo "$fault_type" | tr '[:lower:]' '[:upper:]')
-          # * find cspell configuration
-          cfg_files=($(shopt -s nullglob ; echo {.vscode,.}/{,.}c[sS]pell{.json,.config{.js,.cjs,.json,.yaml,.yml},.yaml,.yml} ;))
-          cfg_file=${cfg_files[0]}
-          unset CSPELL_CFG_OPTION ; if [ -n "$cfg_file" ]; then CSPELL_CFG_OPTION="--config \"$cfg_file\"" ; fi
-          # * `cspell`
-          S=$(cspell ${CSPELL_CFG_OPTION} --no-summary --no-progress "**/*") && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n "s/${PWD//\//\\/}\/(.*):(.*):(.*) - (.*)/::${fault_type} file=\1,line=\2,col=\3::${fault_type^^}: \4 (file:'\1', line:\2)/p" ; fault=true ; true ; }
-          if [ -n "${{ steps.vars.outputs.FAIL_ON_FAULT }}" ] && [ -n "$fault" ]; then exit 1 ; fi
+  # style_spellcheck:
+  #   name: Style/spelling
+  #   runs-on: ${{ matrix.job.os }}
+  #   env:
+  #     STYLE_FAIL_ON_FAULT: false # overrides workflow default
+  #   strategy:
+  #     matrix:
+  #       job:
+  #         - { os: ubuntu-latest }
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Initialize workflow variables
+  #       id: vars
+  #       shell: bash
+  #       run: |
+  #         ## VARs setup
+  #         outputs() { step_id="vars"; for var in "$@" ; do echo steps.${step_id}.outputs.${var}="${!var}"; echo ::set-output name=${var}::${!var}; done; }
+  #         # failure mode
+  #         unset FAIL_ON_FAULT ; case '${{ env.STYLE_FAIL_ON_FAULT }}' in
+  #           ''|0|f|false|n|no|off) FAULT_TYPE=warning ;;
+  #           *) FAIL_ON_FAULT=true ; FAULT_TYPE=error ;;
+  #         esac;
+  #         outputs FAIL_ON_FAULT FAULT_TYPE
+  #     - name: Install/setup prerequisites
+  #       shell: bash
+  #       run: |
+  #         ## Install/setup prerequisites
+  #         sudo apt-get -y update ; sudo apt-get -y install npm ; sudo npm install cspell -g ;
+  #     - name: Run `cspell`
+  #       shell: bash
+  #       run: |
+  #         ## Run `cspell`
+  #         unset fault
+  #         fault_type="${{ steps.vars.outputs.FAULT_TYPE }}"
+  #         fault_prefix=$(echo "$fault_type" | tr '[:lower:]' '[:upper:]')
+  #         # * find cspell configuration
+  #         cfg_files=($(shopt -s nullglob ; echo {.vscode,.}/{,.}c[sS]pell{.json,.config{.js,.cjs,.json,.yaml,.yml},.yaml,.yml} ;))
+  #         cfg_file=${cfg_files[0]}
+  #         unset CSPELL_CFG_OPTION ; if [ -n "$cfg_file" ]; then CSPELL_CFG_OPTION="--config \"$cfg_file\"" ; fi
+  #         # * `cspell`
+  #         S=$(cspell ${CSPELL_CFG_OPTION} --no-summary --no-progress "**/*") && printf "%s\n" "$S" || { printf "%s\n" "$S" ; printf "%s" "$S" | sed -E -n "s/${PWD//\//\\/}\/(.*):(.*):(.*) - (.*)/::${fault_type} file=\1,line=\2,col=\3::${fault_type^^}: \4 (file:'\1', line:\2)/p" ; fault=true ; true ; }
+  #         if [ -n "${{ steps.vars.outputs.FAIL_ON_FAULT }}" ] && [ -n "$fault" ]; then exit 1 ; fi
 
   min_version:
     name: MinRustV # Minimum supported rust version (aka, MinSRV or MSRV)

--- a/src/app.rs
+++ b/src/app.rs
@@ -76,7 +76,7 @@ where
     }
     pub fn render_and_update_board(&mut self) {
         let current_folder = self.file_tree.get_current_folder();
-        self.board.change_files(&current_folder);
+        self.board.change_files(current_folder);
         self.render();
     }
     pub fn increment_loading_progress_indicator(&mut self) {
@@ -175,10 +175,10 @@ where
         self.board.record_current_index_and_zoom_level();
         if let Some(tile) = &self.board.currently_selected() {
             let selected_name = &tile.name;
-            if let Some(file_or_folder) = self.file_tree.item_in_current_folder(&selected_name) {
+            if let Some(file_or_folder) = self.file_tree.item_in_current_folder(selected_name) {
                 match file_or_folder {
                     FileOrFolder::Folder(_) => {
-                        self.file_tree.enter_folder(&selected_name);
+                        self.file_tree.enter_folder(selected_name);
                         self.board.reset_zoom_index();
                         self.board.reset_selected_index();
                         self.render_and_update_board();

--- a/src/input/controls.rs
+++ b/src/input/controls.rs
@@ -172,7 +172,7 @@ pub fn handle_keypress_exiting_mode<B: Backend>(evt: Event, app: &mut App<B>) {
 pub fn handle_keypress_warning_message<B: Backend>(_evt: Event, app: &mut App<B>) {
     // match evt {
     //     _ => {
-            app.reset_ui_mode();
+    app.reset_ui_mode();
     //     }
     // }
 }

--- a/src/input/controls.rs
+++ b/src/input/controls.rs
@@ -169,10 +169,10 @@ pub fn handle_keypress_exiting_mode<B: Backend>(evt: Event, app: &mut App<B>) {
     };
 }
 
-pub fn handle_keypress_warning_message<B: Backend>(evt: Event, app: &mut App<B>) {
-    match evt {
-        _ => {
+pub fn handle_keypress_warning_message<B: Backend>(_evt: Event, app: &mut App<B>) {
+    // match evt {
+    //     _ => {
             app.reset_ui_mode();
-        }
-    }
+    //     }
+    // }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,7 +230,7 @@ pub fn start<B>(
             thread::Builder::new()
                 .name("loading_loop".to_string())
                 .spawn({
-                    let instruction_sender = instruction_sender.clone();
+                    let instruction_sender = instruction_sender;
                     let running = running.clone();
                     move || {
                         while running.load(Ordering::Acquire) && !loaded.load(Ordering::Acquire) {

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -13,7 +13,7 @@ pub(crate) fn is_user_admin() -> bool {
         Value: SECURITY_NT_AUTHORITY,
     };
     let mut admingroup = 0 as PVOID;
-    let ismember = unsafe {
+    unsafe {
         assert!(
             AllocateAndInitializeSid(
                 &mut auth_nt,
@@ -32,8 +32,7 @@ pub(crate) fn is_user_admin() -> bool {
         let mut member: i32 = 0;
         assert!(CheckTokenMembership(0 as PVOID, admingroup, &mut member) != 0);
         member != 0
-    };
-    ismember
+    }
 }
 #[cfg(test)]
 pub(crate) fn is_user_admin() -> bool {

--- a/src/state/files/file_or_folder.rs
+++ b/src/state/files/file_or_folder.rs
@@ -1,7 +1,7 @@
 use ::std::collections::{HashMap, VecDeque};
 use ::std::ffi::OsString;
 use ::std::fs::Metadata;
-use ::std::path::PathBuf;
+use ::std::path::{Path, PathBuf};
 
 use ::filesize::PathExt;
 
@@ -45,7 +45,7 @@ impl From<OsString> for Folder {
     }
 }
 impl Folder {
-    pub fn new(path: &PathBuf) -> Self {
+    pub fn new(path: &Path) -> Self {
         let base_folder_name = path.iter().last().expect("could not get path base name");
         Self {
             name: base_folder_name.to_os_string(),

--- a/src/state/files/file_or_folder.rs
+++ b/src/state/files/file_or_folder.rs
@@ -72,7 +72,7 @@ impl Folder {
             } else {
                 relative_path
                     .size_on_disk_fast(entry_metadata)
-                    .unwrap_or(entry_metadata.len()) as u128
+                    .unwrap_or_else(|_| entry_metadata.len()) as u128
             };
             self.add_file(relative_path, size);
         }
@@ -92,7 +92,7 @@ impl Folder {
             let path_entry = self
                 .contents
                 .entry(name.clone())
-                .or_insert(FileOrFolder::Folder(Folder::from(name)));
+                .or_insert_with(|| FileOrFolder::Folder(Folder::from(name)));
             self.num_descendants += 1;
             match path_entry {
                 FileOrFolder::Folder(folder) => folder.add_folder(path.iter().skip(1).collect()),
@@ -123,7 +123,7 @@ impl Folder {
             let path_entry = self
                 .contents
                 .entry(name.clone())
-                .or_insert(FileOrFolder::Folder(Folder::from(name)));
+                .or_insert_with(|| FileOrFolder::Folder(Folder::from(name)));
             self.size += size;
             self.num_descendants += 1;
             match path_entry {

--- a/src/state/files/file_or_folder.rs
+++ b/src/state/files/file_or_folder.rs
@@ -71,7 +71,7 @@ impl Folder {
                 entry_metadata.len() as u128
             } else {
                 relative_path
-                    .size_on_disk_fast(&entry_metadata)
+                    .size_on_disk_fast(entry_metadata)
                     .unwrap_or(entry_metadata.len()) as u128
             };
             self.add_file(relative_path, size);

--- a/src/state/files/file_tree.rs
+++ b/src/state/files/file_tree.rs
@@ -37,7 +37,7 @@ impl FileTree {
         } else if let Some(FileOrFolder::Folder(current_folder)) =
             self.base_folder.path(self.current_folder_names.clone())
         {
-            &current_folder
+            current_folder
         } else {
             // here we have something in current_folder_names but the last
             // one is somehow not a folder... this is a corrupted state
@@ -67,7 +67,7 @@ impl FileTree {
     }
     pub fn delete_file(&mut self, file_to_delete: &FileToDelete) {
         let path_to_delete = &file_to_delete.path_to_file;
-        self.base_folder.delete_path(&path_to_delete);
+        self.base_folder.delete_path(path_to_delete);
     }
     pub fn add_entry(&mut self, entry_metadata: &Metadata, entry_full_path: &Path) {
         let base_path_length = self.path_in_filesystem.components().count();

--- a/src/state/tiles/board.rs
+++ b/src/state/tiles/board.rs
@@ -89,11 +89,11 @@ impl Board {
                     .iter()
                     .enumerate()
                     .filter(|(_, c)| {
-                        c.is_directly_right_of(&currently_selected)
-                            && c.horizontally_overlaps_with(&currently_selected)
+                        c.is_directly_right_of(currently_selected)
+                            && c.horizontally_overlaps_with(currently_selected)
                     })
                     // get the index of the tile with the most overlap with currently selected
-                    .max_by_key(|(_, c)| c.get_horizontal_overlap_with(&currently_selected))
+                    .max_by_key(|(_, c)| c.get_horizontal_overlap_with(currently_selected))
                     .map(|(index, _)| index);
                 match next_index {
                     Some(i) => self.set_selected_index(&i),
@@ -111,11 +111,11 @@ impl Board {
                     .iter()
                     .enumerate()
                     .filter(|(_, c)| {
-                        c.is_directly_left_of(&currently_selected)
-                            && c.horizontally_overlaps_with(&currently_selected)
+                        c.is_directly_left_of(currently_selected)
+                            && c.horizontally_overlaps_with(currently_selected)
                     })
                     // get the index of the tile with the most overlap with currently selected
-                    .max_by_key(|(_, c)| c.get_horizontal_overlap_with(&currently_selected))
+                    .max_by_key(|(_, c)| c.get_horizontal_overlap_with(currently_selected))
                     .map(|(index, _)| index);
                 match next_index {
                     Some(i) => self.set_selected_index(&i),
@@ -133,11 +133,11 @@ impl Board {
                     .iter()
                     .enumerate()
                     .filter(|(_, c)| {
-                        c.is_directly_below(&currently_selected)
-                            && c.vertically_overlaps_with(&currently_selected)
+                        c.is_directly_below(currently_selected)
+                            && c.vertically_overlaps_with(currently_selected)
                     })
                     // get the index of the tile with the most overlap with currently selected
-                    .max_by_key(|(_, c)| c.get_vertical_overlap_with(&currently_selected))
+                    .max_by_key(|(_, c)| c.get_vertical_overlap_with(currently_selected))
                     .map(|(index, _)| index);
                 match next_index {
                     Some(i) => self.set_selected_index(&i),
@@ -155,11 +155,11 @@ impl Board {
                     .iter()
                     .enumerate()
                     .filter(|(_, c)| {
-                        c.is_directly_above(&currently_selected)
-                            && c.vertically_overlaps_with(&currently_selected)
+                        c.is_directly_above(currently_selected)
+                            && c.vertically_overlaps_with(currently_selected)
                     })
                     // get the index of the tile with the most overlap with currently selected
-                    .max_by_key(|(_, c)| c.get_vertical_overlap_with(&currently_selected))
+                    .max_by_key(|(_, c)| c.get_vertical_overlap_with(currently_selected))
                     .map(|(index, _)| index);
                 match next_index {
                     Some(i) => self.set_selected_index(&i),

--- a/src/state/tiles/files_in_folder.rs
+++ b/src/state/tiles/files_in_folder.rs
@@ -62,9 +62,9 @@ pub fn files_in_folder(folder: &Folder, offset: usize) -> Vec<FileMetadata> {
         let number_of_files_without_removed_contents = folder.contents.len() - removed_items.len();
         let removed_size = removed_items.fold(0, |acc, file| acc + file.size);
         let size_without_removed_items = total_size - removed_size;
-        for i in 0..files.len() {
-            files[i].percentage = calculate_percentage(
-                files[i].size,
+        for file in &mut files {
+            file.percentage = calculate_percentage(
+                file.size,
                 size_without_removed_items,
                 number_of_files_without_removed_contents,
             );

--- a/src/state/tiles/files_in_folder.rs
+++ b/src/state/tiles/files_in_folder.rs
@@ -49,7 +49,7 @@ pub fn files_in_folder(folder: &Folder, offset: usize) -> Vec<FileMetadata> {
         });
     }
     files.sort_by(|a, b| {
-        if a.percentage == b.percentage {
+        if (a.percentage - b.percentage).abs() < f64::EPSILON {
             a.name.partial_cmp(&b.name).expect("could not compare name")
         } else {
             b.percentage

--- a/src/state/tiles/treemap.rs
+++ b/src/state/tiles/treemap.rs
@@ -78,7 +78,7 @@ impl TreeMap {
             };
             progress_in_row += tile_length_first_side;
 
-            let tile = Tile::new(&rect, &file_metadata);
+            let tile = Tile::new(&rect, file_metadata);
             if tile.height < MINIMUM_HEIGHT || tile.width < MINIMUM_WIDTH {
                 self.add_unrenderable_tile(&tile);
             } else {

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -1678,24 +1678,20 @@ fn delete_file() {
             .expect("could not acquire lock on terminal_events")[..],
         &expected_terminal_events[..]
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_2_path).is_err(),
-        true,
         "file successfully deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&subfolder_1_path).is_ok(),
-        true,
         "different folder stayed the same"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_1_path).is_ok(),
-        true,
         "different file was untoucehd"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_3_path).is_ok(),
-        true,
         "second different file was untouched"
     );
     std::fs::remove_dir_all(temp_dir_path).expect("failed to remove temporary folder");
@@ -1769,24 +1765,20 @@ fn delete_file_no_confirmation() {
             .expect("could not acquire lock on terminal_events")[..],
         &expected_terminal_events[..]
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_2_path).is_err(),
-        true,
         "file successfully deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&subfolder_1_path).is_ok(),
-        true,
         "different folder stayed the same"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_1_path).is_ok(),
-        true,
         "different file was untoucehd"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_3_path).is_ok(),
-        true,
         "second different file was untouched"
     );
     std::fs::remove_dir_all(temp_dir_path).expect("failed to remove temporary folder");
@@ -1860,24 +1852,20 @@ fn cant_delete_file_with_term_too_small() {
             .expect("could not acquire lock on terminal_events")[..],
         &expected_terminal_events[..]
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_2_path).is_ok(),
-        true,
         "file not deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&subfolder_1_path).is_ok(),
-        true,
         "different folder stayed the same"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_1_path).is_ok(),
-        true,
         "different file was untoucehd"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_3_path).is_ok(),
-        true,
         "second different file was untouched"
     );
     std::fs::remove_dir_all(temp_dir_path).expect("failed to remove temporary folder");
@@ -1950,24 +1938,20 @@ fn delete_folder() {
             .expect("could not acquire lock on terminal_events")[..],
         &expected_terminal_events[..]
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&subfolder_1_path).is_err(),
-        true,
         "folder successfully deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_1_path).is_err(),
-        true,
         "internal file successfully deleted"
     ); // can't really fail on its own, but left here for clarity
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_2_path).is_ok(),
-        true,
         "different file was untouched"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_3_path).is_ok(),
-        true,
         "second different file was untouched"
     );
     std::fs::remove_dir_all(temp_dir_path).expect("failed to remove temporary folder");
@@ -2047,24 +2031,20 @@ fn delete_folder_no_confirmation() {
             .expect("could not acquire lock on terminal_events")[..],
         &expected_terminal_events[..]
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&subfolder_1_path).is_err(),
-        true,
         "folder successfully deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_1_path).is_err(),
-        true,
         "internal file successfully deleted"
     ); // can't really fail on its own, but left here for clarity
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_2_path).is_ok(),
-        true,
         "different file was untouched"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_3_path).is_ok(),
-        true,
         "second different file was untouched"
     );
     std::fs::remove_dir_all(temp_dir_path).expect("failed to remove temporary folder");
@@ -2149,24 +2129,20 @@ fn delete_folder_small_window() {
             .expect("could not acquire lock on terminal_events")[..],
         &expected_terminal_events[..]
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_2_path).is_ok(),
-        true,
         "different file was untouched"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&subfolder_1_path).is_err(),
-        true,
         "file successfully deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_1_path).is_err(),
-        true,
         "file in folder deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_3_path).is_ok(),
-        true,
         "second different file was untouched"
     );
     std::fs::remove_dir_all(temp_dir_path).expect("failed to remove temporary folder");
@@ -2250,24 +2226,20 @@ fn delete_folder_small_window_no_confirmation() {
             .expect("could not acquire lock on terminal_events")[..],
         &expected_terminal_events[..]
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_2_path).is_ok(),
-        true,
         "different file was untouched"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&subfolder_1_path).is_err(),
-        true,
         "file successfully deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_1_path).is_err(),
-        true,
         "file in folder deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_3_path).is_ok(),
-        true,
         "second different file was untouched"
     );
     std::fs::remove_dir_all(temp_dir_path).expect("failed to remove temporary folder");
@@ -2367,39 +2339,32 @@ fn delete_folder_with_multiple_children() {
             .expect("could not acquire lock on terminal_events")[..],
         &expected_terminal_events[..]
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&subfolder_1_path).is_err(),
-        true,
         "folder successfully deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&subfolder_2_path).is_err(),
-        true,
         "folder inside deleted folder successfully deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_1_path).is_ok(),
-        true,
         "different file was untouched"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_2_path).is_ok(),
-        true,
         "different file was untouched"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_3_path).is_err(),
-        true,
         "internal file in folder deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_4_path).is_err(),
-        true,
         "internal file in folder deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_5_path).is_err(),
-        true,
         "internal file in folder deleted"
     );
     std::fs::remove_dir_all(temp_dir_path).expect("failed to remove temporary folder");
@@ -2497,39 +2462,32 @@ fn delete_folder_with_multiple_children_no_confirmation() {
             .expect("could not acquire lock on terminal_events")[..],
         &expected_terminal_events[..]
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&subfolder_1_path).is_err(),
-        true,
         "folder successfully deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&subfolder_2_path).is_err(),
-        true,
         "folder inside deleted folder successfully deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_1_path).is_ok(),
-        true,
         "different file was untouched"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_2_path).is_ok(),
-        true,
         "different file was untouched"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_3_path).is_err(),
-        true,
         "internal file in folder deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_4_path).is_err(),
-        true,
         "internal file in folder deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_5_path).is_err(),
-        true,
         "internal file in folder deleted"
     );
     std::fs::remove_dir_all(temp_dir_path).expect("failed to remove temporary folder");
@@ -2597,24 +2555,20 @@ fn pressing_delete_with_no_selected_tile() {
             .expect("could not acquire lock on terminal_events")[..],
         &expected_terminal_events[..]
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_2_path).is_ok(),
-        true,
         "file not deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&subfolder_1_path).is_ok(),
-        true,
         "different folder stayed the same"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_1_path).is_ok(),
-        true,
         "different file was untoucehd"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_3_path).is_ok(),
-        true,
         "second different file was untouched"
     );
     std::fs::remove_dir_all(temp_dir_path).expect("failed to remove temporary folder");
@@ -2681,24 +2635,20 @@ fn delete_file_press_n() {
             .expect("could not acquire lock on terminal_events")[..],
         &expected_terminal_events[..]
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_2_path).is_ok(),
-        true,
         "file not deleted"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&subfolder_1_path).is_ok(),
-        true,
         "different folder stayed the same"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_1_path).is_ok(),
-        true,
         "different file was untoucehd"
     );
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_3_path).is_ok(),
-        true,
         "second different file was untouched"
     );
     std::fs::remove_dir_all(temp_dir_path).expect("failed to remove temporary folder");
@@ -2829,14 +2779,12 @@ fn permission_denied_when_deleting() {
         .lock()
         .expect("could not acquire lock on terminal events");
 
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_1_path).is_ok(),
-        true,
         "file was not deleted"
     ); // can't really fail on its own, but left here for clarity
-    assert_eq!(
+    assert!(
         std::fs::metadata(&subfolder_1_path).is_ok(),
-        true,
         "containing folder was not deleted"
     );
 
@@ -2916,14 +2864,12 @@ fn permission_denied_when_deleting_no_confirmation() {
         .lock()
         .expect("could not acquire lock on terminal events");
 
-    assert_eq!(
+    assert!(
         std::fs::metadata(&file_1_path).is_ok(),
-        true,
         "file was not deleted"
     ); // can't really fail on its own, but left here for clarity
-    assert_eq!(
+    assert!(
         std::fs::metadata(&subfolder_1_path).is_ok(),
-        true,
         "containing folder was not deleted"
     );
 

--- a/src/tests/cases/ui.rs
+++ b/src/tests/cases/ui.rs
@@ -1852,10 +1852,7 @@ fn cant_delete_file_with_term_too_small() {
             .expect("could not acquire lock on terminal_events")[..],
         &expected_terminal_events[..]
     );
-    assert!(
-        std::fs::metadata(&file_2_path).is_ok(),
-        "file not deleted"
-    );
+    assert!(std::fs::metadata(&file_2_path).is_ok(), "file not deleted");
     assert!(
         std::fs::metadata(&subfolder_1_path).is_ok(),
         "different folder stayed the same"
@@ -2555,10 +2552,7 @@ fn pressing_delete_with_no_selected_tile() {
             .expect("could not acquire lock on terminal_events")[..],
         &expected_terminal_events[..]
     );
-    assert!(
-        std::fs::metadata(&file_2_path).is_ok(),
-        "file not deleted"
-    );
+    assert!(std::fs::metadata(&file_2_path).is_ok(), "file not deleted");
     assert!(
         std::fs::metadata(&subfolder_1_path).is_ok(),
         "different folder stayed the same"
@@ -2635,10 +2629,7 @@ fn delete_file_press_n() {
             .expect("could not acquire lock on terminal_events")[..],
         &expected_terminal_events[..]
     );
-    assert!(
-        std::fs::metadata(&file_2_path).is_ok(),
-        "file not deleted"
-    );
+    assert!(std::fs::metadata(&file_2_path).is_ok(), "file not deleted");
     assert!(
         std::fs::metadata(&subfolder_1_path).is_ok(),
         "different folder stayed the same"

--- a/src/tests/fakes/fake_output.rs
+++ b/src/tests/fakes/fake_output.rs
@@ -90,11 +90,11 @@ impl Backend for TestBackend {
                         string.push_str(&cell.symbol);
                     }
                     None => {
-                        string.push_str(" ");
+                        string.push(' ');
                     }
                 }
             }
-            string.push_str("\n");
+            string.push('\n');
         }
         self.draw_events.lock().unwrap().push(string);
         Ok(())

--- a/src/ui/bottom_line.rs
+++ b/src/ui/bottom_line.rs
@@ -1,4 +1,4 @@
-use ::std::path::PathBuf;
+use ::std::path::{Path, PathBuf};
 use ::tui::buffer::Buffer;
 use ::tui::layout::Rect;
 use ::tui::style::{Color, Modifier, Style};
@@ -45,7 +45,7 @@ fn render_currently_selected(buf: &mut Buffer, currently_selected: &Tile, max_le
     }
 }
 
-fn render_last_read_path(buf: &mut Buffer, last_read_path: &PathBuf, max_len: u16, y: u16) {
+fn render_last_read_path(buf: &mut Buffer, last_read_path: &Path, max_len: u16, y: u16) {
     let last_read_path = last_read_path.to_string_lossy();
     if (last_read_path.chars().count() as u16) < max_len {
         buf.set_string(1, y, last_read_path, Style::default());

--- a/src/ui/display.rs
+++ b/src/ui/display.rs
@@ -60,7 +60,7 @@ where
                 };
                 let path_in_filesystem = &file_tree.path_in_filesystem;
                 let base_path_info = FolderInfo {
-                    path: &path_in_filesystem,
+                    path: path_in_filesystem,
                     size: base_path_size,
                     num_descendants: base_path_descendants,
                 };

--- a/src/ui/grid/draw_rect.rs
+++ b/src/ui/grid/draw_rect.rs
@@ -103,21 +103,21 @@ pub fn draw_rect_on_grid(buf: &mut Buffer, coords: (u16, u16), dimensions: (u16,
     // top, bottom and corners
     for x in coords_x..(coords_x + width + 1) {
         if x == coords_x {
-            draw_next_symbol(buf, x, coords_y, &boundaries::TOP_LEFT);
-            draw_next_symbol(buf, x, coords_y + height, &boundaries::BOTTOM_LEFT);
+            draw_next_symbol(buf, x, coords_y, boundaries::TOP_LEFT);
+            draw_next_symbol(buf, x, coords_y + height, boundaries::BOTTOM_LEFT);
         } else if x == coords_x + width {
-            draw_next_symbol(buf, x, coords_y, &boundaries::TOP_RIGHT);
-            draw_next_symbol(buf, x, coords_y + height, &boundaries::BOTTOM_RIGHT);
+            draw_next_symbol(buf, x, coords_y, boundaries::TOP_RIGHT);
+            draw_next_symbol(buf, x, coords_y + height, boundaries::BOTTOM_RIGHT);
         } else {
-            draw_next_symbol(buf, x, coords_y, &boundaries::HORIZONTAL);
-            draw_next_symbol(buf, x, coords_y + height, &boundaries::HORIZONTAL);
+            draw_next_symbol(buf, x, coords_y, boundaries::HORIZONTAL);
+            draw_next_symbol(buf, x, coords_y + height, boundaries::HORIZONTAL);
         }
     }
 
     // left and right
     for y in (coords_y + 1)..(coords_y + height) {
-        draw_next_symbol(buf, coords_x, y, &boundaries::VERTICAL);
-        draw_next_symbol(buf, coords_x + width, y, &boundaries::VERTICAL);
+        draw_next_symbol(buf, coords_x, y, boundaries::VERTICAL);
+        draw_next_symbol(buf, coords_x + width, y, boundaries::VERTICAL);
     }
 }
 
@@ -135,24 +135,24 @@ pub fn draw_filled_rect(buf: &mut Buffer, fill_style: Style, rect: &Rect) {
     for x in rect.x..(rect.x + rect.width + 1) {
         if x == rect.x {
             buf.get_mut(x, rect.y)
-                .set_symbol(&boundaries::TOP_LEFT)
+                .set_symbol(boundaries::TOP_LEFT)
                 .set_style(fill_style);
             buf.get_mut(x, rect.y + rect.height)
-                .set_symbol(&boundaries::BOTTOM_LEFT)
+                .set_symbol(boundaries::BOTTOM_LEFT)
                 .set_style(fill_style);
         } else if x == rect.x + rect.width {
             buf.get_mut(x, rect.y)
-                .set_symbol(&boundaries::TOP_RIGHT)
+                .set_symbol(boundaries::TOP_RIGHT)
                 .set_style(fill_style);
             buf.get_mut(x, rect.y + rect.height)
-                .set_symbol(&boundaries::BOTTOM_RIGHT)
+                .set_symbol(boundaries::BOTTOM_RIGHT)
                 .set_style(fill_style);
         } else {
             buf.get_mut(x, rect.y)
-                .set_symbol(&boundaries::HORIZONTAL)
+                .set_symbol(boundaries::HORIZONTAL)
                 .set_style(fill_style);
             buf.get_mut(x, rect.y + rect.height)
-                .set_symbol(&boundaries::HORIZONTAL)
+                .set_symbol(boundaries::HORIZONTAL)
                 .set_style(fill_style);
         }
     }
@@ -160,24 +160,24 @@ pub fn draw_filled_rect(buf: &mut Buffer, fill_style: Style, rect: &Rect) {
     // left and right
     for y in (rect.y + 1)..(rect.y + rect.height) {
         buf.get_mut(rect.x, y)
-            .set_symbol(&boundaries::VERTICAL)
+            .set_symbol(boundaries::VERTICAL)
             .set_style(fill_style);
         buf.get_mut(rect.x + rect.width, y)
-            .set_symbol(&boundaries::VERTICAL)
+            .set_symbol(boundaries::VERTICAL)
             .set_style(fill_style);
     }
 }
 
 pub fn draw_tile_text_on_grid(buf: &mut Buffer, tile: &Tile, selected: bool) {
-    let first_line = tile_first_line(&tile);
+    let first_line = tile_first_line(tile);
     let first_line_length = first_line.width() as u16;
     let first_line_start_position =
         ((tile.width - first_line_length) as f64 / 2.0).ceil() as u16 + tile.x;
-    let second_line = tile_second_line(&tile);
+    let second_line = tile_second_line(tile);
     let second_line_length = second_line.width();
     let second_line_start_position =
         ((tile.width - second_line_length as u16) as f64 / 2.0).ceil() as u16 + tile.x;
-    let (background_style, first_line_style, second_line_style) = tile_style(&tile, selected);
+    let (background_style, first_line_style, second_line_style) = tile_style(tile, selected);
 
     if let Some(background_style) = background_style {
         for x in tile.x + 1..tile.x + tile.width {

--- a/src/ui/grid/rectangle_grid.rs
+++ b/src/ui/grid/rectangle_grid.rs
@@ -71,7 +71,7 @@ impl<'a> Widget for RectangleGrid<'a> {
                 } else {
                     false
                 };
-                draw_tile_text_on_grid(buf, &tile, selected);
+                draw_tile_text_on_grid(buf, tile, selected);
                 draw_rect_on_grid(buf, (tile.x, tile.y), (tile.width, tile.height));
             }
         }

--- a/src/ui/modals/message_box.rs
+++ b/src/ui/modals/message_box.rs
@@ -162,9 +162,9 @@ impl<'a> Widget for MessageBox<'a> {
 
         draw_filled_rect(buf, fill_style, &message_rect);
         if self.deletion_in_progress {
-            render_deletion_in_progress(buf, &message_rect, &self.file_to_delete);
+            render_deletion_in_progress(buf, &message_rect, self.file_to_delete);
         } else {
-            render_deletion_prompt(buf, &message_rect, &self.file_to_delete);
+            render_deletion_prompt(buf, &message_rect, self.file_to_delete);
         }
     }
 }

--- a/src/ui/title/title_line.rs
+++ b/src/ui/title/title_line.rs
@@ -75,7 +75,7 @@ impl<'a> TitleLine<'a> {
 
 impl<'a> Widget for TitleLine<'a> {
     fn render(self, rect: Rect, buf: &mut Buffer) {
-        let base_path = &self
+        let base_path = self
             .base_path_info
             .path
             .clone()
@@ -152,7 +152,7 @@ impl<'a> Widget for TitleLine<'a> {
                 CellSizeOpt::new(" (root)".to_string()).style(default_style.fg(Color::Red)),
             ]);
         }
-        title_telescope.append_to_right_side(vec![CellSizeOpt::new(base_path.to_string())]);
+        title_telescope.append_to_right_side(vec![CellSizeOpt::new(base_path)]);
         if !current_path.is_empty() {
             title_telescope.append_to_right_side(vec![
                 CellSizeOpt::new(format!(

--- a/src/ui/title/title_line.rs
+++ b/src/ui/title/title_line.rs
@@ -148,7 +148,8 @@ impl<'a> Widget for TitleLine<'a> {
             title_telescope.append_to_left_side(vec![
                 CellSizeOpt::new(" (CAUTION: running as root)".to_string())
                     .style(default_style.fg(Color::Red)),
-                CellSizeOpt::new(" (running as root)".to_string()).style(default_style.fg(Color::Red)),
+                CellSizeOpt::new(" (running as root)".to_string())
+                    .style(default_style.fg(Color::Red)),
                 CellSizeOpt::new(" (root)".to_string()).style(default_style.fg(Color::Red)),
             ]);
         }

--- a/src/ui/title/title_line.rs
+++ b/src/ui/title/title_line.rs
@@ -146,9 +146,9 @@ impl<'a> Widget for TitleLine<'a> {
         }
         if is_user_admin() {
             title_telescope.append_to_left_side(vec![
-                CellSizeOpt::new(format!(" (CAUTION: running as root)"))
+                CellSizeOpt::new(" (CAUTION: running as root)".to_string())
                     .style(default_style.fg(Color::Red)),
-                CellSizeOpt::new(format!(" (running as root)")).style(default_style.fg(Color::Red)),
+                CellSizeOpt::new(" (running as root)".to_string()).style(default_style.fg(Color::Red)),
                 CellSizeOpt::new(" (root)".to_string()).style(default_style.fg(Color::Red)),
             ]);
         }


### PR DESCRIPTION
The PR adds a complete GHA CICD workflow:

- includes multiple linux, macos, and windows platform builds and testing
- includes automated packaging and publishing/deployment to GitHub Releases when commit is version tagged
  + fully no-touch/automatically generated (when published version tag of the regex form `[Vv]?\d.*`)
  + includes debian packaging
  + see example at <https://github.com/rivy/rs.diskonaut/releases>
- includes Style testing (both `cargo fmt` and `cargo clippy` warnings); note: warnings add notations but don't break the workflow build
  + there are about 9 distinct `cargo clippy` warnings generated for the current project code
- includes test for minimum rust supported version (aka, MinSRV, MSRV, MinRustV); easily removed if not desired
- includes automatic CodeCov coverage reporting (if/when testing is included); also, easily removed if not desired
  + NOTE: several of the usual code coverage compiler flags cause test errors for this project so coverage here is using only `-Zprofile`, and coverage looks to be skewed (see notes below); I don't have the project knowledge to fix the test failures.

I've been doing some initial experimentation with your project, and I wanted to contribute some automation that might be helpful to you going forward. This contributed workflow is a slightly modified form based on other GHA CICD workflows that I've designed (and are in current use) for [uutils/coreutils](https://github.com/uutils/coreutils), [bootandy/dust](https://github.com/bootandy/dust), [Peltoche/lsd](https://github.com/Peltoche/lsd), [sharkdp/bat](https://github.com/sharkdp/bat), [sharkdp/pastel](https://github.com/sharkdp/pastel).

I'm happy to make any changes that you would find useful as improvements.

### Code coverage notes

For code coverage, the usual flag setting is `RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort'`, but that combination causes compilation failure with:

```text
error[E0463]: can't find crate for `proc_macro_error_attr`
   --> C:\Users\Roy\.cargo\registry\src\github.com-1285ae84e5963aae\proc-macro-error-1.0.2\src\lib.rs:266:9
    |
266 | pub use proc_macro_error_attr::proc_macro_error;
    |         ^^^^^^^^^^^^^^^^^^^^^ can't find crate

error: aborting due to previous error

For more information about this error, try `rustc --explain E0463`.
error: could not compile `proc-macro-error`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error[E0463]: can't find crate for `failure_derive`
  --> C:\Users\Roy\.cargo\registry\src\github.com-1285ae84e5963aae\failure-0.1.8\src\lib.rs:56:1
   |
56 | extern crate failure_derive;
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't find crate

error: aborting due to previous error

For more information about this error, try `rustc --explain E0463`.
error: build failed
```

Using `RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Clink-dead-code -Coverflow-checks=off'`, tests compile but only one test passes:

```text
...

---- tests::cases::ui::zoom_into_small_files stdout ----
---- tests::cases::ui::zoom_into_small_files stderr ----
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "tests run with disabled concurrency, automatic snapshot name generation is not supported.  Consider using the \"backtrace\" feature of insta which tries to recover test names from the call stack."', C:\Users\Roy\.cargo\registry\src\github.com-1285ae84e5963aae\insta-0.16.0\src\runtime.rs:863:22
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

failures:
    tests::cases::ui::cannot_move_into_small_files
    tests::cases::ui::cant_delete_file_with_term_too_small
    tests::cases::ui::clear_selection_when_moving_off_screen_edges
    tests::cases::ui::delete_file
    tests::cases::ui::delete_file_no_confirmation
    tests::cases::ui::delete_file_press_n
    tests::cases::ui::delete_folder
    tests::cases::ui::delete_folder_no_confirmation
    tests::cases::ui::delete_folder_small_window
    tests::cases::ui::delete_folder_small_window_no_confirmation
    tests::cases::ui::delete_folder_with_multiple_children
    tests::cases::ui::delete_folder_with_multiple_children_no_confirmation
    tests::cases::ui::eleven_files
    tests::cases::ui::empty_folder
    tests::cases::ui::enter_folder
    tests::cases::ui::enter_folder_medium_width
    tests::cases::ui::enter_folder_small_width
    tests::cases::ui::enter_largest_folder_with_no_selected_tile
    tests::cases::ui::esc_to_go_up
    tests::cases::ui::files_with_size_zero
    tests::cases::ui::medium_width
    tests::cases::ui::minimum_tile_sides
    tests::cases::ui::move_down_and_enter_folder
    tests::cases::ui::move_left_and_enter_folder
    tests::cases::ui::move_right_and_enter_folder
    tests::cases::ui::move_up_and_enter_folder
    tests::cases::ui::noop_when_entering_file
    tests::cases::ui::noop_when_pressing_esc_at_base_folder
    tests::cases::ui::pressing_delete_with_no_selected_tile
    tests::cases::ui::small_files
    tests::cases::ui::small_files_with_x_as_zero
    tests::cases::ui::small_files_with_y_as_zero
    tests::cases::ui::small_width
    tests::cases::ui::small_width_long_folder_name
    tests::cases::ui::too_small_height
    tests::cases::ui::too_small_width_five
    tests::cases::ui::too_small_width_four
    tests::cases::ui::too_small_width_one
    tests::cases::ui::too_small_width_three
    tests::cases::ui::too_small_width_two
    tests::cases::ui::two_large_files_one_small_file
    tests::cases::ui::zoom_into_small_files

test result: FAILED. 1 passed; 42 failed; 0 ignored; 0 measured; 0 filtered out
```

Using `RUSTFLAGS: '-Zprofile -Clink-dead-code -Coverflow-checks=off'`, tests compile but two test failures occur:

```text
failures:
tests::cases::ui::delete_file_no_confirmation
tests::cases::ui::delete_folder_no_confirmation

test result: FAILED. 41 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
```
