### PR TITLE
Added production-ready Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+target
+.gitignore
+.travis.yml
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+demo.gif
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM rust:latest AS build
+ADD . /app
+WORKDIR /app
+RUN cargo build --release
+FROM debian:buster-slim
+COPY --from=build /app/target/release/diskonaut /bin/diskonaut
+ENTRYPOINT ["/bin/diskonaut"]


### PR DESCRIPTION
Hey, We added production-ready Dockerfile to ur project. U can add CI/CD to that to automate pushing to Docker Hub. If u want to test how it works u have to build image.

```sh
docker build . -t diskonaut
```

After that u can use it as normally installed app.

```sh
docker run -t -v absolute_path:container_path diskonaut container_path
```

Co-Authored-By: kaurelia <60290504+kaurelia@users.noreply.github.com>